### PR TITLE
feat: notch foundation (v0.1-alpha) — NSPanel, geometry, expand/collapse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ DerivedData/
 *.dSYM
 build/
 
+# XcodeGen — the project is generated from project.yml, never committed
+gh-notch.xcodeproj/
+
 # Swift Package Manager
 .build/
 .swiftpm/

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,34 @@
+opt_in_rules:
+  - empty_count
+  - closure_spacing
+  - force_unwrapping
+  - first_where
+  - sorted_imports
+  - explicit_init
+  - redundant_nil_coalescing
+
+disabled_rules:
+  - todo
+
+excluded:
+  - .build
+  - DerivedData
+  - gh-notch.xcodeproj
+
+line_length:
+  warning: 120
+  error: 160
+  ignores_comments: true
+
+identifier_name:
+  min_length:
+    warning: 2
+  excluded:
+    - id
+    - x
+    - y
+
+# force_unwrapping is opt-in above and left at error severity: no force-unwraps
+# in non-test code (see DEVELOPMENT.md).
+force_cast: error
+force_try: error

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,6 +10,7 @@ This guide covers everything you need to build gh-notch from source and contribu
 |---|---|---|
 | Xcode | 16.0+ | Required. Download from Mac App Store or developer.apple.com |
 | macOS | 14.0 Sonoma+ | Earlier versions will not work (notch APIs require Sonoma) |
+| XcodeGen | Any | Required — the `.xcodeproj` is generated, not committed. `brew install xcodegen` |
 | SwiftLint | Any | Optional but recommended — `brew install swiftlint` |
 | Git | Any | Comes with Xcode Command Line Tools |
 
@@ -22,59 +23,78 @@ This guide covers everything you need to build gh-notch from source and contribu
 git clone https://github.com/aymandakir-gh/gh-notch.git
 cd gh-notch
 
-# 2. Open the Xcode project
+# 2. Generate the Xcode project from project.yml
+xcodegen generate
+
+# 3. Open it
 open gh-notch.xcodeproj
 
-# 3. Set your signing team
+# 4. Set your signing team
 # Xcode → gh-notch target → Signing & Capabilities → Team → select your Apple ID
 
-# 4. Build and run
+# 5. Build and run
 # Cmd+R  (or Product → Run)
 ```
 
-The app runs as a menu-bar / notch app — no Dock icon will appear. Look for it in the notch area or menu bar after launch.
+The app runs as a menu-bar / notch app — no Dock icon will appear. After launch,
+look at the notch area: you'll see a collapsed black pill that expands into a
+panel on hover or click. (Features mount into that panel in later slices.)
 
-> **Note:** The Xcode project (`gh-notch.xcodeproj`) will be added in v0.1-alpha.
-> If you want to contribute before then, check the [Issues tab](https://github.com/aymandakir-gh/gh-notch/issues) — early contributors can help define the project structure, Swift package layout, and initial SwiftUI components.
+> **Why XcodeGen?** The `.xcodeproj` is generated from `project.yml` and is
+> git-ignored, so there are no merge conflicts on project file internals. Edit
+> `project.yml` (targets, build settings, Info.plist keys) and re-run
+> `xcodegen generate` — never hand-edit the generated project.
 
 ---
 
-## Project structure (planned)
+## Project structure
 
 ```
 gh-notch/
+├── project.yml                     # XcodeGen spec (source of truth for the project)
+├── .swiftlint.yml
 ├── gh-notch/
 │   ├── App/
 │   │   ├── gh_notchApp.swift       # @main entry point
-│   │   └── AppDelegate.swift       # NSApplicationDelegate
+│   │   └── AppDelegate.swift       # NSApplicationDelegate — panel boot + screen observer
 │   ├── Notch/
-│   │   ├── NotchPanel.swift        # NSPanel positioning + geometry
-│   │   └── NotchViewModel.swift    # State + expand/collapse logic
-│   ├── Features/
-│   │   ├── AICommandBar/           # Text input, parser, dispatcher
-│   │   ├── MediaControls/          # Now Playing + visualizer
-│   │   ├── Calendar/               # EventKit integration
-│   │   ├── FileShelf/              # Drag-and-drop + AirDrop
-│   │   ├── BatteryHUD/             # IOKit battery status
-│   │   └── SystemHUD/              # Brightness/volume intercept
-│   ├── Extensions/                 # Future plugin system
-│   ├── Settings/                   # SwiftUI settings window
+│   │   ├── NotchGeometry.swift     # safeAreaInsets sampling + fallback (no hardcoded sizes)
+│   │   ├── NotchPanel.swift        # NSPanel positioning + level + collection behavior
+│   │   ├── NotchViewModel.swift    # @Observable expand/collapse state + frame math
+│   │   └── NotchView.swift         # SwiftUI root (collapsed pill ↔ expanded surface)
+│   ├── Features/                   # (later slices) AICommandBar, MediaControls, Calendar, …
+│   ├── Settings/                   # (later slice) SwiftUI settings window
 │   └── Resources/
-│       └── Info.plist
-├── gh-notchTests/
-└── docs/
+│       └── Info.plist              # LSUIElement = YES
+└── gh-notchTests/
+    └── NotchViewModelTests.swift
 ```
+
+The `Features/`, `Settings/`, and `Extensions/` groups are not yet populated —
+the foundation slice ships the notch substrate only. See the roadmap in the
+README for what lands next.
 
 ---
 
 ## Architecture notes for contributors
 
 - **SwiftUI + AppKit hybrid.** Use SwiftUI for all views. Drop to AppKit (`NSPanel`, `NSScreen`, `NSEvent`) only where SwiftUI has no equivalent.
-- **No force-unwraps** in any non-test code path. Use `guard let` and handle the nil/error case explicitly.
+- **No force-unwraps** in any non-test code path. Use `guard let` and handle the nil/error case explicitly. Enforced by SwiftLint (`force_unwrapping` is an error).
 - **Privacy by default.** If a feature touches user data (calendar, clipboard, microphone), gate it behind a permission check and explain the request in plain language.
-- **Notch geometry is sampled at runtime** from `NSScreen.main?.safeAreaInsets.top` — never hardcode pixel values.
+- **Notch geometry is sampled at runtime** from `NSScreen.safeAreaInsets.top` — never hardcode pixel values. See `NotchGeometry.swift`.
 - See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for deeper technical context.
 - See [docs/AI-COMMAND-BAR.md](docs/AI-COMMAND-BAR.md) for the AI feature design spec.
+
+---
+
+## Running tests
+
+```bash
+# From the project root, after xcodegen generate
+xcodebuild test -scheme gh-notch -destination 'platform=macOS'
+```
+
+Or run them from Xcode with Cmd+U.
 
 ---
 
@@ -88,7 +108,7 @@ swiftlint
 swiftlint --fix
 ```
 
-SwiftLint config (`.swiftlint.yml`) will be added alongside the Xcode project in v0.1-alpha.
+SwiftLint config lives in `.swiftlint.yml`.
 
 ---
 

--- a/gh-notch/App/AppDelegate.swift
+++ b/gh-notch/App/AppDelegate.swift
@@ -1,0 +1,48 @@
+import AppKit
+import SwiftUI
+
+/// AppKit lifecycle owner.
+///
+/// Responsibilities for this slice (v0.1-alpha foundation):
+/// - Activate the app as an accessory (no Dock icon, no main menu focus steal).
+/// - Build the notch panel and attach the SwiftUI root view.
+/// - Reposition the panel when the active screen or its geometry changes.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+
+    private let viewModel = NotchViewModel()
+    private var notchPanel: NotchPanel?
+    private var screenObserver: NSObjectProtocol?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Accessory: lives in the notch, not the Dock. Mirrors LSUIElement so
+        // behavior is correct even if the plist is overridden at runtime.
+        NSApp.setActivationPolicy(.accessory)
+
+        let panel = NotchPanel(viewModel: viewModel)
+        panel.attachContent(NotchView(viewModel: viewModel))
+        panel.repositionToActiveScreen()
+        panel.orderFrontRegardless()
+        notchPanel = panel
+
+        observeScreenChanges()
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        if let screenObserver {
+            NotificationCenter.default.removeObserver(screenObserver)
+        }
+        screenObserver = nil
+    }
+
+    /// Reposition when displays are connected/disconnected or resolution changes
+    /// (e.g. plugging in an external monitor, or the menu bar resizing).
+    private func observeScreenChanges() {
+        screenObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.notchPanel?.repositionToActiveScreen()
+        }
+    }
+}

--- a/gh-notch/App/gh_notchApp.swift
+++ b/gh-notch/App/gh_notchApp.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Entry point for gh-notch.
+///
+/// The app is a notch / menu-bar utility with no Dock icon (`LSUIElement` is set
+/// in `Info.plist`). SwiftUI owns the `@main` declaration, but all window
+/// management happens in `AppDelegate` via AppKit, because the notch panel needs
+/// `NSPanel` APIs that SwiftUI does not expose.
+///
+/// We deliberately declare an empty `Settings` scene rather than a `WindowGroup`:
+/// a `WindowGroup` would create a standard app window at launch, which we do not
+/// want. `Settings` provides a valid scene with no visible window until the user
+/// opens preferences (wired up in a later slice).
+@main
+struct GhNotchApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
+    var body: some Scene {
+        Settings {
+            EmptyView()
+        }
+    }
+}

--- a/gh-notch/Notch/NotchGeometry.swift
+++ b/gh-notch/Notch/NotchGeometry.swift
@@ -1,0 +1,100 @@
+import AppKit
+
+/// Runtime description of a display's notch (or lack of one).
+///
+/// All values are sampled from `NSScreen` at runtime — never hardcoded per model,
+/// per ARCHITECTURE.md. On non-notched displays `hasNotch` is `false` and the
+/// caller falls back to a floating top-center bar.
+struct NotchGeometry: Equatable {
+
+    /// Whether the active screen physically has a notch.
+    let hasNotch: Bool
+
+    /// The notch bounds in screen coordinates (origin bottom-left, AppKit style),
+    /// i.e. the rectangle the panel should occupy when collapsed. On non-notched
+    /// displays this is a synthesized top-center rectangle of `fallbackWidth`.
+    let collapsedFrame: NSRect
+
+    /// Height of the menu-bar / notch region for the active screen.
+    let notchHeight: CGFloat
+
+    // MARK: - Tunables
+
+    /// Width used for the collapsed pill when the display has no notch, or when
+    /// the notch width cannot be derived from `safeAreaInsets`.
+    static let fallbackWidth: CGFloat = 220
+
+    /// Default collapsed height when `safeAreaInsets.top` is zero (non-notched).
+    static let fallbackHeight: CGFloat = 32
+
+    /// Memberwise initializer. Used by the screen-driven factory below and by
+    /// tests, which cannot run the screen sampler headlessly.
+    init(hasNotch: Bool, collapsedFrame: NSRect, notchHeight: CGFloat) {
+        self.hasNotch = hasNotch
+        self.collapsedFrame = collapsedFrame
+        self.notchHeight = notchHeight
+    }
+
+    // MARK: - Sampling
+
+    /// Build geometry for the screen that currently hosts the menu bar.
+    ///
+    /// Returns `nil` only when there is no screen at all (headless / between
+    /// display reconfiguration), which the caller treats as "skip this update".
+    static func forActiveScreen() -> NotchGeometry? {
+        guard let screen = activeScreen() else { return nil }
+        return NotchGeometry(screen: screen)
+    }
+
+    /// The screen the menu bar lives on. `NSScreen.main` follows the key window,
+    /// which we never have, so prefer the screen whose frame origin is (0,0) —
+    /// that is the menu-bar screen in AppKit's global coordinate space.
+    static func activeScreen() -> NSScreen? {
+        let screens = NSScreen.screens
+        if let primary = screens.first(where: { $0.frame.origin == .zero }) {
+            return primary
+        }
+        return NSScreen.main ?? screens.first
+    }
+
+    private init(screen: NSScreen) {
+        let topInset = screen.safeAreaInsets.top
+        let frame = screen.frame
+
+        // A non-zero top safe-area inset on a macOS display means a notch.
+        let notched = topInset > 0
+        self.hasNotch = notched
+
+        let height = notched ? topInset : NotchGeometry.fallbackHeight
+        self.notchHeight = height
+
+        let width: CGFloat
+        if notched {
+            // The notch is centered. `auxiliaryTopLeftArea` / `auxiliaryTopRightArea`
+            // (macOS 12+) bound the usable menu-bar areas; the gap between them is
+            // the notch. Fall back to a sensible default if unavailable.
+            width = NotchGeometry.notchWidth(for: screen) ?? NotchGeometry.fallbackWidth
+        } else {
+            width = NotchGeometry.fallbackWidth
+        }
+
+        // Top-center rectangle in AppKit coordinates (origin bottom-left).
+        let originX = frame.midX - (width / 2)
+        let originY = frame.maxY - height
+        self.collapsedFrame = NSRect(x: originX, y: originY, width: width, height: height)
+    }
+
+    /// Derive notch width from the gap between the left and right menu-bar areas.
+    /// Returns `nil` if the auxiliary areas are not exposed (older hardware/OS),
+    /// letting the caller use `fallbackWidth`.
+    private static func notchWidth(for screen: NSScreen) -> CGFloat? {
+        guard
+            let leftArea = screen.auxiliaryTopLeftArea,
+            let rightArea = screen.auxiliaryTopRightArea
+        else {
+            return nil
+        }
+        let gap = rightArea.minX - leftArea.maxX
+        return gap > 0 ? gap : nil
+    }
+}

--- a/gh-notch/Notch/NotchPanel.swift
+++ b/gh-notch/Notch/NotchPanel.swift
@@ -1,0 +1,82 @@
+import AppKit
+import SwiftUI
+
+/// Borderless `NSPanel` that hosts the SwiftUI notch UI.
+///
+/// Renders above the menu bar (`.screenSaver` level), joins every Space, is
+/// non-activating (clicking it never steals key focus from the user's app), and
+/// is transparent so SwiftUI controls the visible shape.
+final class NotchPanel: NSPanel {
+
+    private let viewModel: NotchViewModel
+
+    init(viewModel: NotchViewModel) {
+        self.viewModel = viewModel
+
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: NotchGeometry.fallbackWidth, height: NotchGeometry.fallbackHeight),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        isFloatingPanel = true
+        level = .screenSaver                     // above the menu bar
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = false
+        isMovable = false
+        isMovableByWindowBackground = false
+        hidesOnDeactivate = false
+        ignoresMouseEvents = false
+
+        // Visible on every Space, and over full-screen apps' menu bar region.
+        collectionBehavior = [
+            .canJoinAllSpaces,
+            .stationary,
+            .fullScreenAuxiliary,
+            .ignoresCycle
+        ]
+
+        // Re-frame the window whenever the view model expands/collapses.
+        viewModel.onLayoutChange = { [weak self] in
+            self?.applyCurrentFrame()
+        }
+    }
+
+    /// Borderless panels return `false` by default; allow key so SwiftUI focus
+    /// (e.g. the future AI command bar text field) can work when expanded.
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+
+    /// Install the SwiftUI root as the panel's content.
+    func attachContent<Content: View>(_ content: Content) {
+        let hosting = NSHostingView(rootView: content)
+        hosting.translatesAutoresizingMaskIntoConstraints = true
+        hosting.autoresizingMask = [.width, .height]
+        contentView = hosting
+    }
+
+    /// Sample the active screen and move/size the panel to match the view model's
+    /// current frame. Safe to call repeatedly (screen changes, expand/collapse).
+    func repositionToActiveScreen() {
+        guard let geometry = NotchGeometry.forActiveScreen() else { return }
+        viewModel.update(geometry: geometry)
+        applyCurrentFrame()
+    }
+
+    /// Resize/reposition to whatever the view model currently reports, animating
+    /// the expand/collapse transition.
+    func applyCurrentFrame(animated: Bool = true) {
+        guard let frame = viewModel.currentFrame else { return }
+        if animated {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.22
+                context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                animator().setFrame(frame, display: true)
+            }
+        } else {
+            setFrame(frame, display: true)
+        }
+    }
+}

--- a/gh-notch/Notch/NotchView.swift
+++ b/gh-notch/Notch/NotchView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// SwiftUI root rendered inside the notch panel.
+///
+/// Foundation slice: a collapsed black pill that hugs the notch and expands into
+/// an empty surface on hover/click. Feature widgets (media, calendar, AI bar,
+/// etc.) will mount into the expanded area in later slices.
+struct NotchView: View {
+    @Bindable var viewModel: NotchViewModel
+    @State private var isHovering = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            collapsedBar
+            if viewModel.isExpanded {
+                expandedSurface
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(panelShape)
+        .onHover { hovering in
+            isHovering = hovering
+            // Hover-to-peek: expand on enter, collapse on leave. A click also
+            // toggles, for trackpad users who prefer an explicit tap.
+            if hovering {
+                viewModel.expand()
+            } else {
+                viewModel.collapse()
+            }
+        }
+        .animation(.easeOut(duration: 0.22), value: viewModel.isExpanded)
+    }
+
+    // MARK: - Collapsed
+
+    private var collapsedBar: some View {
+        HStack {
+            Spacer(minLength: 0)
+        }
+        .frame(height: collapsedHeight)
+        .contentShape(Rectangle())
+        .onTapGesture { viewModel.toggle() }
+    }
+
+    private var collapsedHeight: CGFloat {
+        viewModel.geometry?.notchHeight ?? NotchGeometry.fallbackHeight
+    }
+
+    // MARK: - Expanded
+
+    private var expandedSurface: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 22, weight: .regular))
+                .foregroundStyle(.secondary)
+            Text("gh-notch")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.primary)
+            Text("Foundation ready — features mount here.")
+                .font(.system(size: 11))
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(16)
+    }
+
+    // MARK: - Shape
+
+    /// The notch silhouette: square top corners (flush with the screen edge),
+    /// rounded bottom corners. Expanding only grows downward, so the top stays
+    /// glued to the physical notch.
+    private var panelShape: some View {
+        UnevenRoundedRectangle(
+            topLeadingRadius: 0,
+            bottomLeadingRadius: bottomRadius,
+            bottomTrailingRadius: bottomRadius,
+            topTrailingRadius: 0,
+            style: .continuous
+        )
+        .fill(.black)
+        .overlay(
+            UnevenRoundedRectangle(
+                topLeadingRadius: 0,
+                bottomLeadingRadius: bottomRadius,
+                bottomTrailingRadius: bottomRadius,
+                topTrailingRadius: 0,
+                style: .continuous
+            )
+            .strokeBorder(.white.opacity(viewModel.isExpanded ? 0.08 : 0), lineWidth: 1)
+        )
+    }
+
+    private var bottomRadius: CGFloat {
+        viewModel.isExpanded ? 16 : 10
+    }
+}
+
+#Preview {
+    NotchView(viewModel: NotchViewModel())
+        .frame(width: 360, height: 232)
+        .background(Color.gray)
+}

--- a/gh-notch/Notch/NotchViewModel.swift
+++ b/gh-notch/Notch/NotchViewModel.swift
@@ -1,0 +1,80 @@
+import AppKit
+import Observation
+
+/// Observable state for the notch panel.
+///
+/// Owns the collapse/expand state and the most recently sampled geometry. The
+/// panel reads `currentFrame` to size/position its window; the SwiftUI view reads
+/// `isExpanded` to choose its layout.
+@Observable
+final class NotchViewModel {
+
+    /// Whether the panel is showing its expanded surface (true) or the collapsed
+    /// pill that hugs the notch (false).
+    var isExpanded: Bool = false
+
+    /// The latest geometry sampled from the active screen. `nil` before the first
+    /// sample (e.g. headless boot); the panel skips positioning until it is set.
+    private(set) var geometry: NotchGeometry?
+
+    /// User override for notch width (Settings, future slice). When non-nil it
+    /// replaces the sampled width. Stubbed now; no UI yet.
+    var notchWidthOverride: CGFloat?
+
+    /// Size of the expanded surface. Fixed for the foundation slice; features will
+    /// later drive this from their content.
+    let expandedSize = NSSize(width: 360, height: 200)
+
+    /// Invoked after any state change that alters `currentFrame` (expand/collapse).
+    /// The panel sets this to reposition/resize its window. Not part of observable
+    /// state — it is an imperative side-effect hook, kept out of `@ObservationIgnored`
+    /// reads by being a plain stored closure the panel owns.
+    @ObservationIgnored var onLayoutChange: (() -> Void)?
+
+    /// Update the stored geometry from a fresh sample.
+    func update(geometry: NotchGeometry) {
+        self.geometry = geometry
+    }
+
+    func toggle() {
+        isExpanded.toggle()
+        onLayoutChange?()
+    }
+
+    func collapse() {
+        guard isExpanded else { return }
+        isExpanded = false
+        onLayoutChange?()
+    }
+
+    func expand() {
+        guard !isExpanded else { return }
+        isExpanded = true
+        onLayoutChange?()
+    }
+
+    /// The frame the panel window should occupy right now, in AppKit screen
+    /// coordinates. Returns `nil` until geometry has been sampled at least once.
+    var currentFrame: NSRect? {
+        guard let geometry else { return nil }
+        let collapsed = collapsedFrame(from: geometry)
+        guard isExpanded else { return collapsed }
+
+        // Expanded surface drops down from under the notch, centered on it.
+        let width = max(expandedSize.width, collapsed.width)
+        let height = expandedSize.height + collapsed.height
+        let originX = collapsed.midX - (width / 2)
+        let originY = collapsed.maxY - height
+        return NSRect(x: originX, y: originY, width: width, height: height)
+    }
+
+    /// Collapsed frame with the user width override applied, if any.
+    private func collapsedFrame(from geometry: NotchGeometry) -> NSRect {
+        guard let override = notchWidthOverride, override > 0 else {
+            return geometry.collapsedFrame
+        }
+        let base = geometry.collapsedFrame
+        let originX = base.midX - (override / 2)
+        return NSRect(x: originX, y: base.origin.y, width: override, height: base.height)
+    }
+}

--- a/gh-notch/Resources/Info.plist
+++ b/gh-notch/Resources/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleDisplayName</key>
+	<string>gh-notch</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>MIT License. Copyright (c) 2026 GrowthHackers.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/gh-notchTests/NotchViewModelTests.swift
+++ b/gh-notchTests/NotchViewModelTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import gh_notch
+
+final class NotchViewModelTests: XCTestCase {
+
+    func testStartsCollapsed() {
+        let viewModel = NotchViewModel()
+        XCTAssertFalse(viewModel.isExpanded)
+    }
+
+    func testToggleFlipsStateAndFiresLayoutChange() {
+        let viewModel = NotchViewModel()
+        var layoutChangeCount = 0
+        viewModel.onLayoutChange = { layoutChangeCount += 1 }
+
+        viewModel.toggle()
+        XCTAssertTrue(viewModel.isExpanded)
+        XCTAssertEqual(layoutChangeCount, 1)
+
+        viewModel.toggle()
+        XCTAssertFalse(viewModel.isExpanded)
+        XCTAssertEqual(layoutChangeCount, 2)
+    }
+
+    func testExpandAndCollapseAreIdempotent() {
+        let viewModel = NotchViewModel()
+        var layoutChangeCount = 0
+        viewModel.onLayoutChange = { layoutChangeCount += 1 }
+
+        viewModel.expand()
+        viewModel.expand() // no-op, already expanded
+        XCTAssertTrue(viewModel.isExpanded)
+        XCTAssertEqual(layoutChangeCount, 1)
+
+        viewModel.collapse()
+        viewModel.collapse() // no-op, already collapsed
+        XCTAssertFalse(viewModel.isExpanded)
+        XCTAssertEqual(layoutChangeCount, 2)
+    }
+
+    func testCurrentFrameIsNilWithoutGeometry() {
+        let viewModel = NotchViewModel()
+        XCTAssertNil(viewModel.currentFrame)
+    }
+
+    func testCollapsedFrameMatchesGeometry() {
+        let viewModel = NotchViewModel()
+        let collapsed = NSRect(x: 800, y: 1060, width: 200, height: 32)
+        let geometry = NotchGeometry.stub(collapsedFrame: collapsed, notchHeight: 32, hasNotch: true)
+        viewModel.update(geometry: geometry)
+
+        XCTAssertEqual(viewModel.currentFrame, collapsed)
+    }
+
+    func testExpandedFrameGrowsDownwardAndStaysTopAligned() {
+        let viewModel = NotchViewModel()
+        let collapsed = NSRect(x: 800, y: 1060, width: 200, height: 32)
+        let geometry = NotchGeometry.stub(collapsedFrame: collapsed, notchHeight: 32, hasNotch: true)
+        viewModel.update(geometry: geometry)
+        viewModel.expand()
+
+        guard let frame = viewModel.currentFrame else {
+            return XCTFail("expected a frame once geometry is set")
+        }
+        // Top edge unchanged (glued to the notch).
+        XCTAssertEqual(frame.maxY, collapsed.maxY, accuracy: 0.001)
+        // Centered on the notch.
+        XCTAssertEqual(frame.midX, collapsed.midX, accuracy: 0.001)
+        // Taller than collapsed.
+        XCTAssertGreaterThan(frame.height, collapsed.height)
+    }
+
+    func testNotchWidthOverrideIsApplied() {
+        let viewModel = NotchViewModel()
+        let collapsed = NSRect(x: 800, y: 1060, width: 200, height: 32)
+        let geometry = NotchGeometry.stub(collapsedFrame: collapsed, notchHeight: 32, hasNotch: true)
+        viewModel.update(geometry: geometry)
+        viewModel.notchWidthOverride = 300
+
+        guard let frame = viewModel.currentFrame else {
+            return XCTFail("expected a frame once geometry is set")
+        }
+        XCTAssertEqual(frame.width, 300, accuracy: 0.001)
+        XCTAssertEqual(frame.midX, collapsed.midX, accuracy: 0.001)
+    }
+}
+
+// MARK: - Test helpers
+
+extension NotchGeometry {
+    /// Memberwise stub for tests. The production initializer is screen-driven and
+    /// cannot run headlessly, so tests construct geometry directly.
+    static func stub(collapsedFrame: NSRect, notchHeight: CGFloat, hasNotch: Bool) -> NotchGeometry {
+        NotchGeometry(hasNotch: hasNotch, collapsedFrame: collapsedFrame, notchHeight: notchHeight)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,63 @@
+name: gh-notch
+
+options:
+  bundleIdPrefix: company.gh
+  deploymentTarget:
+    macOS: "14.0"
+  createIntermediateGroups: true
+
+settings:
+  base:
+    MARKETING_VERSION: "0.1.0"
+    CURRENT_PROJECT_VERSION: "1"
+    SWIFT_VERSION: "5.9"
+    DEVELOPMENT_TEAM: "" # set your Apple Developer Team ID in Xcode → Signing & Capabilities
+    CODE_SIGN_STYLE: Automatic
+    ENABLE_HARDENED_RUNTIME: YES
+
+targets:
+  gh-notch:
+    type: application
+    platform: macOS
+    sources:
+      - path: gh-notch
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: company.gh.notch
+        INFOPLIST_FILE: gh-notch/Resources/Info.plist
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        COMBINE_HIDPI_IMAGES: YES
+        LD_RUNPATH_SEARCH_PATHS:
+          - "$(inherited)"
+          - "@executable_path/../Frameworks"
+    info:
+      path: gh-notch/Resources/Info.plist
+      properties:
+        LSUIElement: true
+        CFBundleDisplayName: gh-notch
+        LSMinimumSystemVersion: "14.0"
+        NSHumanReadableCopyright: "MIT License. Copyright (c) 2026 GrowthHackers."
+
+  gh-notchTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: gh-notchTests
+    dependencies:
+      - target: gh-notch
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: company.gh.notchTests
+
+schemes:
+  gh-notch:
+    build:
+      targets:
+        gh-notch: all
+        gh-notchTests: [test]
+    run:
+      config: Debug
+    test:
+      config: Debug
+      targets:
+        - gh-notchTests


### PR DESCRIPTION
## v0.1-alpha — Notch Foundation

First actual code for gh-notch. Ships the substrate every feature depends on: a transparent `NSPanel` that renders above the menu bar, samples notch geometry at runtime, and expands/collapses. No feature logic — foundation only.

### What's in here
- **`project.yml`** — XcodeGen spec (macOS 14 target, `LSUIElement`, app + unit-test targets). The `.xcodeproj` is generated, not committed (now git-ignored).
- **`App/`** — `@main` SwiftUI entry with an empty `Settings` scene (no launch window) + `AppDelegate` running as `.accessory` (no Dock icon), booting the panel and re-positioning on screen changes.
- **`Notch/`**
  - `NotchGeometry` — samples `NSScreen.safeAreaInsets.top` for notch height and derives width from the gap between `auxiliaryTopLeftArea`/`auxiliaryTopRightArea`. Falls back to a top-center bar on non-notched displays. No hardcoded per-model sizes (per ARCHITECTURE.md).
  - `NotchPanel` — borderless non-activating `NSPanel`, `.screenSaver` level, joins all Spaces, transparent so SwiftUI owns the shape.
  - `NotchViewModel` — `@Observable` expand/collapse state + frame math (expands downward, stays glued to the notch). Stubs a `notchWidthOverride` for the future Settings slice.
  - `NotchView` — collapsed black pill ↔ expanded surface with the notch silhouette (square top, rounded bottom). Hover-to-peek + tap-to-toggle.
- **Tests** — `NotchViewModelTests` covers state transitions, idempotent expand/collapse, and frame math (top-aligned, centered, width override).
- **Tooling** — `.swiftlint.yml` with `force_unwrapping` as an error in non-test code.

### Deviation from spec (flagged)
DEVELOPMENT.md previously said "open `gh-notch.xcodeproj`". Hand-writing a `.pbxproj` blind (uncompilable in this environment) is fragile, so this uses **XcodeGen** instead. DEVELOPMENT.md is updated: `brew install xcodegen` → `xcodegen generate` → `open`.

### Not verified
Written without a local Xcode build (repo isn't mounted). Needs a `xcodegen generate` + Cmd+R + Cmd+U pass on a notched Mac before merge. Watch points:
- `auxiliaryTopLeftArea`/`auxiliaryTopRightArea` returning the expected notch gap on real hardware.
- `@testable import gh_notch` resolving (module name = product name with `-` → `_`).
- Panel actually rendering above the menu bar at `.screenSaver` level.

### Out of scope
All features (media, calendar, AI command bar, file shelf, battery HUD, system HUD) and the Settings UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)