### PR TITLE
ci: build, test & lint on GitHub macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build · Test · Lint
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode 16
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16"
+
+      - name: Install tooling
+        run: brew install xcodegen swiftlint xcbeautify
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: SwiftLint
+        run: swiftlint --reporter github-actions-logging
+
+      - name: Build & test
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -scheme gh-notch \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcbeautify --renderer github-actions


### PR DESCRIPTION
Adds `.github/workflows/ci.yml`. On every push to `main` and every PR, a macOS-15 runner (full Xcode 16) does:

1. `xcodegen generate`
2. `swiftlint` (GitHub annotations)
3. `xcodebuild test -scheme gh-notch -destination 'platform=macOS'` — builds the app and runs `NotchViewModelTests`, unsigned (`CODE_SIGNING_ALLOWED=NO`)

This gives the project a real build+test loop on a true Xcode toolchain — the verification that can't run on a Command-Line-Tools-only laptop. The first run will tell us definitively whether the foundation builds and the unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)