### PR TITLE
feat: MVP — local AI command bar + battery HUD

### DIFF
--- a/gh-notch/Features/Battery/BatteryMonitor.swift
+++ b/gh-notch/Features/Battery/BatteryMonitor.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Observation
+
+/// Observable battery state, polled on an interval.
+///
+/// IOKit also exposes a run-loop notification source for power changes, but a
+/// short poll is simpler, dependency-light, and accurate enough for a HUD. The
+/// reader is injected so the poll logic is unit-testable without hardware.
+@Observable
+final class BatteryMonitor {
+
+    private(set) var snapshot: BatterySnapshot
+
+    @ObservationIgnored private let reader: PowerSourceReading
+    @ObservationIgnored private let interval: TimeInterval
+    @ObservationIgnored private var timer: Timer?
+
+    init(reader: PowerSourceReading = IOKitPowerSourceReader(), interval: TimeInterval = 30) {
+        self.reader = reader
+        self.interval = interval
+        self.snapshot = reader.read()
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    /// Take a reading immediately. Safe to call from the main thread.
+    func refresh() {
+        snapshot = reader.read()
+    }
+
+    /// Begin periodic polling. Called when the panel appears.
+    func start() {
+        guard timer == nil else { return }
+        refresh()
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            self?.refresh()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    /// Stop polling. Called when the panel disappears.
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+}

--- a/gh-notch/Features/Battery/BatterySnapshot.swift
+++ b/gh-notch/Features/Battery/BatterySnapshot.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// A point-in-time reading of the system battery.
+struct BatterySnapshot: Equatable {
+    /// Charge level, 0...100.
+    let percent: Int
+    /// Whether the battery is actively charging.
+    let isCharging: Bool
+    /// Whether the machine is on AC power.
+    let isPluggedIn: Bool
+    /// Minutes until empty (on battery) or full (charging). `nil` while macOS is
+    /// still estimating, or when there is no battery (desktop).
+    let minutesRemaining: Int?
+
+    /// Whether the host has a battery at all. Desktops report `false`.
+    let hasBattery: Bool
+
+    /// Snapshot for a machine with no battery (Mac mini / Studio / external use).
+    static let noBattery = BatterySnapshot(
+        percent: 100,
+        isCharging: false,
+        isPluggedIn: true,
+        minutesRemaining: nil,
+        hasBattery: false
+    )
+
+    /// Human-readable time estimate, e.g. "1:25 left" / "0:40 to full".
+    var timeDescription: String? {
+        guard hasBattery, let minutes = minutesRemaining, minutes > 0 else { return nil }
+        let hours = minutes / 60
+        let mins = minutes % 60
+        let clock = String(format: "%d:%02d", hours, mins)
+        return isCharging ? "\(clock) to full" : "\(clock) left"
+    }
+}

--- a/gh-notch/Features/Battery/BatteryView.swift
+++ b/gh-notch/Features/Battery/BatteryView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// Compact battery indicator: SF Symbol that reflects level + charging state,
+/// the percentage, and a time estimate when macOS provides one.
+struct BatteryView: View {
+    @Bindable var monitor: BatteryMonitor
+
+    var body: some View {
+        let snapshot = monitor.snapshot
+
+        HStack(spacing: 8) {
+            Image(systemName: symbolName(for: snapshot))
+                .font(.system(size: 15))
+                .foregroundStyle(tint(for: snapshot))
+                .symbolRenderingMode(.hierarchical)
+
+            if snapshot.hasBattery {
+                Text("\(snapshot.percent)%")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .monospacedDigit()
+
+                if let time = snapshot.timeDescription {
+                    Text(time)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Text("No battery")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func symbolName(for snapshot: BatterySnapshot) -> String {
+        guard snapshot.hasBattery else { return "powerplug" }
+        if snapshot.isCharging { return "battery.100percent.bolt" }
+        switch snapshot.percent {
+        case ..<10: return "battery.0percent"
+        case ..<35: return "battery.25percent"
+        case ..<60: return "battery.50percent"
+        case ..<85: return "battery.75percent"
+        default: return "battery.100percent"
+        }
+    }
+
+    private func tint(for snapshot: BatterySnapshot) -> Color {
+        if snapshot.isCharging || snapshot.isPluggedIn { return .green }
+        if snapshot.hasBattery && snapshot.percent <= 10 { return .red }
+        return .primary
+    }
+}
+
+#Preview {
+    BatteryView(monitor: BatteryMonitor())
+        .frame(width: 200)
+        .padding()
+        .background(Color.black)
+}

--- a/gh-notch/Features/Battery/PowerSourceReader.swift
+++ b/gh-notch/Features/Battery/PowerSourceReader.swift
@@ -1,0 +1,52 @@
+import Foundation
+import IOKit.ps
+
+/// Reads a `BatterySnapshot` from the system. Abstracted behind a protocol so the
+/// monitor can be unit-tested with a stub (IOKit cannot run headlessly in CI).
+protocol PowerSourceReading {
+    func read() -> BatterySnapshot
+}
+
+/// Live reader backed by IOKit `IOPowerSources`.
+struct IOKitPowerSourceReader: PowerSourceReading {
+
+    func read() -> BatterySnapshot {
+        guard
+            let blob = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+            let sources = IOPSCopyPowerSourcesList(blob)?.takeRetainedValue() as? [CFTypeRef],
+            let first = sources.first,
+            let description = IOPSGetPowerSourceDescription(blob, first)?.takeUnretainedValue() as? [String: Any]
+        else {
+            return .noBattery
+        }
+        return Self.snapshot(from: description)
+    }
+
+    /// Map an IOKit power-source description dictionary to a `BatterySnapshot`.
+    /// Exposed `internal` so tests can exercise the mapping with synthetic dicts.
+    static func snapshot(from description: [String: Any]) -> BatterySnapshot {
+        let maxCapacity = description[kIOPSMaxCapacityKey] as? Int ?? 0
+        let currentCapacity = description[kIOPSCurrentCapacityKey] as? Int ?? 0
+        let percent = maxCapacity > 0
+            ? Int((Double(currentCapacity) / Double(maxCapacity) * 100).rounded())
+            : currentCapacity
+
+        let isCharging = description[kIOPSIsChargingKey] as? Bool ?? false
+        let powerState = description[kIOPSPowerSourceStateKey] as? String
+        let isPluggedIn = powerState == kIOPSACPowerValue
+
+        // IOKit reports -1 while the estimate is still being computed.
+        let rawTime: Int? = isCharging
+            ? description[kIOPSTimeToFullChargeKey] as? Int
+            : description[kIOPSTimeToEmptyKey] as? Int
+        let minutesRemaining = rawTime.flatMap { $0 >= 0 ? $0 : nil }
+
+        return BatterySnapshot(
+            percent: min(max(percent, 0), 100),
+            isCharging: isCharging,
+            isPluggedIn: isPluggedIn,
+            minutesRemaining: minutesRemaining,
+            hasBattery: true
+        )
+    }
+}

--- a/gh-notch/Features/CommandBar/ArithmeticEvaluator.swift
+++ b/gh-notch/Features/CommandBar/ArithmeticEvaluator.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// A tiny, crash-free arithmetic evaluator for the command bar.
+///
+/// Supports `+ - * /`, parentheses, unary minus, and decimals. Returns `nil` on
+/// any malformed input instead of raising — unlike `NSExpression`, which can
+/// throw Objective-C exceptions that Swift cannot catch. Recursive-descent over
+/// the grammar:
+///
+///     expression = term (('+' | '-') term)*
+///     term       = factor (('*' | '/') factor)*
+///     factor     = '-' factor | '(' expression ')' | number
+enum ArithmeticEvaluator {
+
+    /// Evaluate `input`, returning the numeric result or `nil` if it is not a
+    /// well-formed arithmetic expression (or evaluates to a non-finite value,
+    /// e.g. division by zero).
+    static func evaluate(_ input: String) -> Double? {
+        var parser = Parser(input)
+        guard let value = parser.parseExpression() else { return nil }
+        guard parser.isAtEnd else { return nil }
+        return value.isFinite ? value : nil
+    }
+
+    private struct Parser {
+        private let characters: [Character]
+        private var position = 0
+
+        init(_ input: String) {
+            characters = Array(input)
+        }
+
+        mutating func parseExpression() -> Double? {
+            guard var result = parseTerm() else { return nil }
+            while let op = peekOperator(in: ["+", "-"]) {
+                advance()
+                guard let rhs = parseTerm() else { return nil }
+                result = op == "+" ? result + rhs : result - rhs
+            }
+            return result
+        }
+
+        private mutating func parseTerm() -> Double? {
+            guard var result = parseFactor() else { return nil }
+            while let op = peekOperator(in: ["*", "/"]) {
+                advance()
+                guard let rhs = parseFactor() else { return nil }
+                result = op == "*" ? result * rhs : result / rhs
+            }
+            return result
+        }
+
+        private mutating func parseFactor() -> Double? {
+            skipSpaces()
+            guard let char = current else { return nil }
+
+            if char == "-" {
+                advance()
+                guard let value = parseFactor() else { return nil }
+                return -value
+            }
+            if char == "(" {
+                advance()
+                guard let value = parseExpression() else { return nil }
+                skipSpaces()
+                guard current == ")" else { return nil }
+                advance()
+                return value
+            }
+            return parseNumber()
+        }
+
+        private mutating func parseNumber() -> Double? {
+            skipSpaces()
+            var digits = ""
+            var seenDot = false
+            while let char = current {
+                if char.isNumber {
+                    digits.append(char)
+                    advance()
+                } else if char == "." && !seenDot {
+                    seenDot = true
+                    digits.append(char)
+                    advance()
+                } else {
+                    break
+                }
+            }
+            return Double(digits)
+        }
+
+        // MARK: - Cursor helpers
+
+        var isAtEnd: Bool {
+            mutating get {
+                skipSpaces()
+                return position >= characters.count
+            }
+        }
+
+        private var current: Character? {
+            position < characters.count ? characters[position] : nil
+        }
+
+        private mutating func advance() {
+            position += 1
+        }
+
+        private mutating func skipSpaces() {
+            while let char = current, char == " " || char == "\t" {
+                advance()
+            }
+        }
+
+        private mutating func peekOperator(in operators: Set<Character>) -> Character? {
+            skipSpaces()
+            guard let char = current, operators.contains(char) else { return nil }
+            return char
+        }
+    }
+}

--- a/gh-notch/Features/CommandBar/CommandBarView.swift
+++ b/gh-notch/Features/CommandBar/CommandBarView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+/// The AI command bar: a Spotlight-style text field rendered in the notch.
+///
+/// MVP: parses locally (math, counts, transforms, date). The result line shows
+/// underneath; a small badge marks whether it was resolved on-device.
+struct CommandBarView: View {
+    @Bindable var viewModel: CommandBarViewModel
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: "sparkle.magnifyingglass")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+
+                TextField("Type a command…", text: $viewModel.input)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.primary)
+                    .focused($isFocused)
+                    .onSubmit { viewModel.submit() }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(.white.opacity(0.08))
+            )
+
+            if let result = viewModel.result {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Image(systemName: result.handledLocally ? "lock.fill" : "cloud")
+                        .font(.system(size: 9))
+                        .foregroundStyle(result.handledLocally ? .green : .orange)
+                        .help(result.handledLocally ? "Resolved on-device" : "Would dispatch to your AI endpoint")
+                    Text(result.output)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.primary)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeOut(duration: 0.15), value: viewModel.result)
+        .onAppear { isFocused = true }
+    }
+}
+
+#Preview {
+    CommandBarView(viewModel: CommandBarViewModel())
+        .frame(width: 340)
+        .padding()
+        .background(Color.black)
+}

--- a/gh-notch/Features/CommandBar/CommandBarViewModel.swift
+++ b/gh-notch/Features/CommandBar/CommandBarViewModel.swift
@@ -1,0 +1,27 @@
+import Observation
+
+/// State for the command-bar input + last result.
+@Observable
+final class CommandBarViewModel {
+
+    var input: String = ""
+    private(set) var result: CommandResult?
+
+    private let parser: CommandParser
+
+    init(parser: CommandParser = CommandParser()) {
+        self.parser = parser
+    }
+
+    /// Parse the current input and store the result. No-op on empty input.
+    func submit() {
+        guard let result = parser.parse(input) else { return }
+        self.result = result
+    }
+
+    /// Clear input and result (e.g. on collapse or Esc).
+    func reset() {
+        input = ""
+        result = nil
+    }
+}

--- a/gh-notch/Features/CommandBar/CommandParser.swift
+++ b/gh-notch/Features/CommandBar/CommandParser.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Outcome of parsing a command-bar entry.
+struct CommandResult: Equatable {
+    /// Text to show the user.
+    let output: String
+    /// `true` when a local handler resolved the command without leaving the
+    /// device. `false` means the full app would dispatch this to the user's
+    /// configured AI endpoint (not wired up in the MVP).
+    let handledLocally: Bool
+}
+
+/// Privacy-first command parser.
+///
+/// Per the AI Command Bar design spec, every entry is parsed locally first.
+/// Nothing leaves the device. Free-form queries that no local handler matches
+/// fall through to a placeholder result; the remote-dispatch path (Ollama /
+/// Claude / OpenAI) lands in a later slice.
+///
+/// Supported local commands:
+/// - Arithmetic: `2 + 2 * (3 - 1)`
+/// - `count <text>` / `wc <text>` — word and character count
+/// - `upper <text>` / `lower <text>` — case transforms
+/// - `date` / `time` / `now` — current date and time
+/// - `help` — list commands
+struct CommandParser {
+
+    /// Injectable clock so `date`/`time` are testable.
+    var now: () -> Date = Date.init
+
+    /// Parse `raw`. Returns `nil` for empty input (nothing to show).
+    func parse(_ raw: String) -> CommandResult? {
+        let input = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !input.isEmpty else { return nil }
+        let lowered = input.lowercased()
+
+        if lowered == "help" {
+            return local(CommandParser.helpText)
+        }
+        if lowered == "date" || lowered == "time" || lowered == "now" {
+            return local(Self.dateFormatter.string(from: now()))
+        }
+        if let rest = remainder(after: "count ", in: input) ?? remainder(after: "wc ", in: input) {
+            let words = rest.split { $0.isWhitespace }.count
+            let characters = rest.count
+            return local("\(words) words · \(characters) characters")
+        }
+        if let rest = remainder(after: "upper ", in: input) {
+            return local(rest.uppercased())
+        }
+        if let rest = remainder(after: "lower ", in: input) {
+            return local(rest.lowercased())
+        }
+        if let value = ArithmeticEvaluator.evaluate(input) {
+            return local(Self.format(value))
+        }
+
+        return CommandResult(
+            output: "No local handler. Add an AI endpoint in Settings to send this to your model.",
+            handledLocally: false
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func local(_ output: String) -> CommandResult {
+        CommandResult(output: output, handledLocally: true)
+    }
+
+    /// Case-insensitive prefix match; returns the trimmed remainder, or `nil`.
+    private func remainder(after prefix: String, in input: String) -> String? {
+        guard input.lowercased().hasPrefix(prefix.lowercased()) else { return nil }
+        let body = String(input.dropFirst(prefix.count))
+        let trimmed = body.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Format a numeric result: drop the decimal for whole numbers, otherwise
+    /// trim to a sensible precision.
+    static func format(_ value: Double) -> String {
+        if value.rounded() == value && abs(value) < 1e15 {
+            return String(Int(value))
+        }
+        return Self.numberFormatter.string(from: NSNumber(value: value)) ?? String(value)
+    }
+
+    static let helpText = """
+    Commands: math (2+2), count <text>, wc <text>, upper <text>, lower <text>, date, time, help
+    """
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    private static let numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 6
+        formatter.usesGroupingSeparator = false
+        return formatter
+    }()
+}

--- a/gh-notch/Notch/NotchView.swift
+++ b/gh-notch/Notch/NotchView.swift
@@ -2,12 +2,13 @@ import SwiftUI
 
 /// SwiftUI root rendered inside the notch panel.
 ///
-/// Foundation slice: a collapsed black pill that hugs the notch and expands into
-/// an empty surface on hover/click. Feature widgets (media, calendar, AI bar,
-/// etc.) will mount into the expanded area in later slices.
+/// Collapsed: a black pill that hugs the notch. Expanded (on hover/click): the
+/// MVP widgets — the local AI command bar and the battery HUD.
 struct NotchView: View {
     @Bindable var viewModel: NotchViewModel
     @State private var isHovering = false
+    @State private var commandBar = CommandBarViewModel()
+    @State private var battery = BatteryMonitor()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -50,20 +51,19 @@ struct NotchView: View {
     // MARK: - Expanded
 
     private var expandedSurface: some View {
-        VStack(spacing: 8) {
-            Image(systemName: "sparkles")
-                .font(.system(size: 22, weight: .regular))
-                .foregroundStyle(.secondary)
-            Text("gh-notch")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.primary)
-            Text("Foundation ready — features mount here.")
-                .font(.system(size: 11))
-                .foregroundStyle(.tertiary)
-                .multilineTextAlignment(.center)
+        VStack(alignment: .leading, spacing: 12) {
+            CommandBarView(viewModel: commandBar)
+            Divider()
+                .overlay(Color.white.opacity(0.1))
+            BatteryView(monitor: battery)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .onAppear { battery.start() }
+        .onDisappear {
+            battery.stop()
+            commandBar.reset()
+        }
     }
 
     // MARK: - Shape
@@ -99,6 +99,6 @@ struct NotchView: View {
 
 #Preview {
     NotchView(viewModel: NotchViewModel())
-        .frame(width: 360, height: 232)
+        .frame(width: 380, height: 200)
         .background(Color.gray)
 }

--- a/gh-notch/Notch/NotchViewModel.swift
+++ b/gh-notch/Notch/NotchViewModel.swift
@@ -21,9 +21,9 @@ final class NotchViewModel {
     /// replaces the sampled width. Stubbed now; no UI yet.
     var notchWidthOverride: CGFloat?
 
-    /// Size of the expanded surface. Fixed for the foundation slice; features will
-    /// later drive this from their content.
-    let expandedSize = NSSize(width: 360, height: 200)
+    /// Size of the expanded surface. Sized for the MVP widgets (command bar +
+    /// battery row); features will later drive this from their content.
+    let expandedSize = NSSize(width: 380, height: 168)
 
     /// Invoked after any state change that alters `currentFrame` (expand/collapse).
     /// The panel sets this to reposition/resize its window. Not part of observable

--- a/gh-notchTests/ArithmeticEvaluatorTests.swift
+++ b/gh-notchTests/ArithmeticEvaluatorTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import gh_notch
+
+final class ArithmeticEvaluatorTests: XCTestCase {
+
+    func testAddition() {
+        XCTAssertEqual(ArithmeticEvaluator.evaluate("2 + 2"), 4)
+    }
+
+    func testOperatorPrecedence() {
+        XCTAssertEqual(ArithmeticEvaluator.evaluate("2 + 3 * 4"), 14)
+    }
+
+    func testParentheses() {
+        XCTAssertEqual(ArithmeticEvaluator.evaluate("(2 + 3) * 4"), 20)
+    }
+
+    func testUnaryMinus() {
+        XCTAssertEqual(ArithmeticEvaluator.evaluate("-5 + 8"), 3)
+    }
+
+    func testDecimals() {
+        guard let value = ArithmeticEvaluator.evaluate("0.5 * 3") else {
+            return XCTFail("expected a value")
+        }
+        XCTAssertEqual(value, 1.5, accuracy: 0.0001)
+    }
+
+    func testNestedParentheses() {
+        XCTAssertEqual(ArithmeticEvaluator.evaluate("((1 + 2) * (3 + 4))"), 21)
+    }
+
+    func testDivisionByZeroIsNil() {
+        XCTAssertNil(ArithmeticEvaluator.evaluate("1 / 0"))
+    }
+
+    func testMalformedInputIsNil() {
+        XCTAssertNil(ArithmeticEvaluator.evaluate("2 +"))
+        XCTAssertNil(ArithmeticEvaluator.evaluate("hello"))
+        XCTAssertNil(ArithmeticEvaluator.evaluate("(1 + 2"))
+        XCTAssertNil(ArithmeticEvaluator.evaluate("2 2"))
+        XCTAssertNil(ArithmeticEvaluator.evaluate(""))
+    }
+}

--- a/gh-notchTests/BatteryTests.swift
+++ b/gh-notchTests/BatteryTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+import IOKit.ps
+@testable import gh_notch
+
+final class BatteryTests: XCTestCase {
+
+    // MARK: - Snapshot mapping from IOKit dictionaries
+
+    func testMapsDischargingSnapshot() {
+        let description: [String: Any] = [
+            kIOPSMaxCapacityKey: 100,
+            kIOPSCurrentCapacityKey: 72,
+            kIOPSIsChargingKey: false,
+            kIOPSPowerSourceStateKey: kIOPSBatteryPowerValue,
+            kIOPSTimeToEmptyKey: 85
+        ]
+        let snapshot = IOKitPowerSourceReader.snapshot(from: description)
+
+        XCTAssertEqual(snapshot.percent, 72)
+        XCTAssertFalse(snapshot.isCharging)
+        XCTAssertFalse(snapshot.isPluggedIn)
+        XCTAssertEqual(snapshot.minutesRemaining, 85)
+        XCTAssertTrue(snapshot.hasBattery)
+        XCTAssertEqual(snapshot.timeDescription, "1:25 left")
+    }
+
+    func testMapsChargingSnapshot() {
+        let description: [String: Any] = [
+            kIOPSMaxCapacityKey: 100,
+            kIOPSCurrentCapacityKey: 40,
+            kIOPSIsChargingKey: true,
+            kIOPSPowerSourceStateKey: kIOPSACPowerValue,
+            kIOPSTimeToFullChargeKey: 40
+        ]
+        let snapshot = IOKitPowerSourceReader.snapshot(from: description)
+
+        XCTAssertEqual(snapshot.percent, 40)
+        XCTAssertTrue(snapshot.isCharging)
+        XCTAssertTrue(snapshot.isPluggedIn)
+        XCTAssertEqual(snapshot.timeDescription, "0:40 to full")
+    }
+
+    func testNegativeTimeEstimateIsTreatedAsCalculating() {
+        let description: [String: Any] = [
+            kIOPSMaxCapacityKey: 100,
+            kIOPSCurrentCapacityKey: 55,
+            kIOPSIsChargingKey: false,
+            kIOPSPowerSourceStateKey: kIOPSBatteryPowerValue,
+            kIOPSTimeToEmptyKey: -1
+        ]
+        let snapshot = IOKitPowerSourceReader.snapshot(from: description)
+
+        XCTAssertNil(snapshot.minutesRemaining)
+        XCTAssertNil(snapshot.timeDescription)
+    }
+
+    func testPercentIsClampedAndDerivedFromCapacityRatio() {
+        let description: [String: Any] = [
+            kIOPSMaxCapacityKey: 80,
+            kIOPSCurrentCapacityKey: 40, // 50%
+            kIOPSIsChargingKey: false,
+            kIOPSPowerSourceStateKey: kIOPSBatteryPowerValue
+        ]
+        let snapshot = IOKitPowerSourceReader.snapshot(from: description)
+        XCTAssertEqual(snapshot.percent, 50)
+    }
+
+    func testNoBatterySnapshotHasNoTimeDescription() {
+        XCTAssertFalse(BatterySnapshot.noBattery.hasBattery)
+        XCTAssertNil(BatterySnapshot.noBattery.timeDescription)
+    }
+
+    // MARK: - Monitor with injected reader
+
+    func testMonitorReadsFromInjectedReaderOnInit() {
+        let stub = StubReader(snapshot: makeSnapshot(percent: 33))
+        let monitor = BatteryMonitor(reader: stub, interval: 999)
+        XCTAssertEqual(monitor.snapshot.percent, 33)
+    }
+
+    func testMonitorRefreshPullsLatestReading() {
+        let stub = StubReader(snapshot: makeSnapshot(percent: 33))
+        let monitor = BatteryMonitor(reader: stub, interval: 999)
+        stub.snapshot = makeSnapshot(percent: 90)
+        monitor.refresh()
+        XCTAssertEqual(monitor.snapshot.percent, 90)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSnapshot(percent: Int) -> BatterySnapshot {
+        BatterySnapshot(
+            percent: percent,
+            isCharging: false,
+            isPluggedIn: false,
+            minutesRemaining: nil,
+            hasBattery: true
+        )
+    }
+
+    private final class StubReader: PowerSourceReading {
+        var snapshot: BatterySnapshot
+        init(snapshot: BatterySnapshot) { self.snapshot = snapshot }
+        func read() -> BatterySnapshot { snapshot }
+    }
+}

--- a/gh-notchTests/CommandParserTests.swift
+++ b/gh-notchTests/CommandParserTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import gh_notch
+
+final class CommandParserTests: XCTestCase {
+
+    private let parser = CommandParser()
+
+    func testEmptyInputReturnsNil() {
+        XCTAssertNil(parser.parse(""))
+        XCTAssertNil(parser.parse("   "))
+    }
+
+    func testMathIsHandledLocally() {
+        let result = parser.parse("2 + 2 * 3")
+        XCTAssertEqual(result?.output, "8")
+        XCTAssertEqual(result?.handledLocally, true)
+    }
+
+    func testWordCount() {
+        let result = parser.parse("count the quick brown fox")
+        XCTAssertEqual(result?.output, "4 words · 19 characters")
+        XCTAssertEqual(result?.handledLocally, true)
+    }
+
+    func testWordCountShortAlias() {
+        XCTAssertEqual(parser.parse("wc hello world")?.output, "2 words · 11 characters")
+    }
+
+    func testUpperAndLower() {
+        XCTAssertEqual(parser.parse("upper hello")?.output, "HELLO")
+        XCTAssertEqual(parser.parse("lower HELLO")?.output, "hello")
+    }
+
+    func testHelp() {
+        let result = parser.parse("help")
+        XCTAssertEqual(result?.handledLocally, true)
+        XCTAssertTrue(result?.output.contains("math") ?? false)
+    }
+
+    func testDateUsesInjectedClock() {
+        let fixed = Date(timeIntervalSince1970: 0)
+        let clockParser = CommandParser(now: { fixed })
+        let result = clockParser.parse("date")
+        XCTAssertEqual(result?.handledLocally, true)
+        XCTAssertFalse(result?.output.isEmpty ?? true)
+    }
+
+    func testUnrecognizedFallsBackToRemote() {
+        let result = parser.parse("what is the capital of France")
+        XCTAssertEqual(result?.handledLocally, false)
+        XCTAssertTrue(result?.output.contains("Settings") ?? false)
+    }
+}


### PR DESCRIPTION
First two working features mounted into the notch panel. Both are self-contained: no permissions, no network, no paid account — so CI fully verifies them.

## AI Command Bar (local mode)
The README differentiator, local-only for the MVP:
- **`ArithmeticEvaluator`** — recursive-descent math (`+ - * /`, parens, unary minus, decimals). Returns `nil` on malformed input instead of crashing, unlike `NSExpression` (which can raise uncatchable ObjC exceptions). Division-by-zero → nil.
- **`CommandParser`** — privacy-first: parses on-device first. Handles `math`, `count`/`wc <text>`, `upper`/`lower <text>`, `date`/`time`/`now`, `help`. Anything unmatched returns a "configure an AI endpoint in Settings" fallback (`handledLocally: false`) — the remote dispatch (Ollama/Claude/OpenAI) is a later slice.
- **`CommandBarView`** — Spotlight-style text field with a result line; a 🔒/☁️ badge marks on-device vs. would-be-remote.

## Battery HUD
- **`IOKitPowerSourceReader`** — reads `IOPowerSources`, maps to a `BatterySnapshot` (percent from capacity ratio, charging state, AC state, time-to-empty/full with the `-1 = still estimating` case handled). Behind a `PowerSourceReading` protocol so it's testable without hardware.
- **`BatteryMonitor`** — `@Observable`, 30s poll, injected reader. Handles the no-battery (desktop) case.
- **`BatteryView`** — SF Symbol by level + charging, percentage, time estimate.

## Wiring
`NotchView`'s expanded surface now hosts the command bar + battery row (was a placeholder). Panel resized for the widgets. Battery polling starts on expand, stops + command bar resets on collapse.

## Tests (22 new assertions)
- `ArithmeticEvaluatorTests` — precedence, nesting, div-by-zero, malformed
- `CommandParserTests` — each command + injected-clock date + remote fallback
- `BatteryTests` — IOKit dict → snapshot mapping (charging/discharging/calculating/clamping), monitor with stub reader

## Verification
- Type-checked clean locally (Command Line Tools).
- CI (Xcode 16) runs build + all tests + SwiftLint on this PR.
- **Still needs a human eyeball in Xcode** for the visual side: command-bar focus behavior in a borderless panel, hover-expand feel, battery glyph rendering. Logic is unit-covered; appearance is not.

## Not in scope
Remote AI dispatch + Settings UI; media controls, calendar, file shelf, system HUD; distribution (needs the Apple Developer Program — see the standing blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)