### PR TITLE
feat: remote AI dispatch + Settings + secure storage + release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release
+
+# Builds, (optionally) signs + notarizes, packages a DMG, and attaches it to a
+# GitHub Release when a v* tag is pushed.
+#
+# Signing + notarization run ONLY when the signing secrets are present. Until the
+# GH Apple Developer Program account exists, pushing a tag still produces an
+# *unsigned* DMG artifact (users must right-click → Open). Once the secrets are
+# added (see RELEASING.md), the same workflow produces a signed + notarized DMG.
+#
+# Required repository secrets for signed builds:
+#   MACOS_CERTIFICATE_P12_BASE64  - base64 of the Developer ID Application .p12
+#   MACOS_CERTIFICATE_PASSWORD    - password for that .p12
+#   MACOS_SIGNING_IDENTITY        - e.g. "Developer ID Application: GH S.R.L. (TEAMID)"
+#   APPLE_ID                      - Apple ID email for notarytool
+#   APPLE_TEAM_ID                 - 10-char team id
+#   APPLE_APP_SPECIFIC_PASSWORD   - app-specific password for the Apple ID
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build & package
+    runs-on: macos-15
+    env:
+      MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode 16
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16"
+
+      - name: Install tooling
+        run: brew install xcodegen create-dmg
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Import signing certificate
+        if: env.MACOS_CERTIFICATE_P12_BASE64 != ''
+        run: |
+          set -euo pipefail
+          KEYCHAIN=build.keychain
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          echo "$MACOS_CERTIFICATE_P12_BASE64" | base64 --decode > certificate.p12
+          security import certificate.p12 -k "$KEYCHAIN" -P "$MACOS_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain
+          rm -f certificate.p12
+
+      - name: Build & archive
+        run: |
+          set -euo pipefail
+          SIGN_FLAGS=()
+          if [ -n "${MACOS_SIGNING_IDENTITY:-}" ]; then
+            SIGN_FLAGS=(CODE_SIGN_IDENTITY="$MACOS_SIGNING_IDENTITY" CODE_SIGN_STYLE=Manual)
+          else
+            SIGN_FLAGS=(CODE_SIGNING_ALLOWED=NO)
+          fi
+          xcodebuild archive \
+            -scheme gh-notch \
+            -configuration Release \
+            -destination 'generic/platform=macOS' \
+            -archivePath build/gh-notch.xcarchive \
+            "${SIGN_FLAGS[@]}"
+
+      - name: Export app
+        run: |
+          set -euo pipefail
+          mkdir -p build/export
+          cp -R "build/gh-notch.xcarchive/Products/Applications/gh-notch.app" build/export/
+
+      - name: Notarize & staple
+        if: env.APPLE_ID != '' && env.MACOS_SIGNING_IDENTITY != ''
+        run: |
+          set -euo pipefail
+          ditto -c -k --keepParent "build/export/gh-notch.app" build/gh-notch.zip
+          xcrun notarytool submit build/gh-notch.zip \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --wait
+          xcrun stapler staple "build/export/gh-notch.app"
+
+      - name: Create DMG
+        run: |
+          set -euo pipefail
+          create-dmg \
+            --volname "gh-notch" \
+            --window-size 540 380 \
+            --icon-size 100 \
+            --app-drop-link 380 180 \
+            "build/gh-notch-${GITHUB_REF_NAME}.dmg" \
+            "build/export/" || \
+          hdiutil create -volname "gh-notch" -srcfolder "build/export/" -ov -format UDZO \
+            "build/gh-notch-${GITHUB_REF_NAME}.dmg"
+
+      - name: Attach DMG to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/gh-notch-${{ github.ref_name }}.dmg
+          generate_release_notes: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,63 @@
+# Releasing gh-notch
+
+Releases are built by `.github/workflows/release.yml`, triggered by pushing a
+`v*` tag. The same workflow handles both the unsigned (pre-enrollment) and the
+signed + notarized (post-enrollment) cases.
+
+## TL;DR
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+A GitHub Release is created with a `.dmg` attached.
+
+## Two modes
+
+### Unsigned (today, before Apple Developer Program enrollment)
+
+With no signing secrets configured, the workflow builds an **unsigned** DMG.
+Users must bypass Gatekeeper manually: right-click the app → **Open** → **Open**.
+This is fine for testing and early adopters, **not** for a public "just works"
+release.
+
+### Signed + notarized (after enrollment)
+
+This is the requirement for a real public release — without it macOS Gatekeeper
+blocks the app on other people's machines. It needs:
+
+1. **A paid Apple Developer Program membership** ($99/yr) for GH S.R.L. — this is
+   the gating business decision. A free Apple ID cannot sign for distribution.
+2. A **Developer ID Application** certificate exported as a `.p12`.
+3. An **app-specific password** for the Apple ID used to notarize.
+
+Add these as repository secrets (Settings → Secrets and variables → Actions):
+
+| Secret | What it is |
+|---|---|
+| `MACOS_CERTIFICATE_P12_BASE64` | `base64 -i DeveloperID.p12` output |
+| `MACOS_CERTIFICATE_PASSWORD` | password set when exporting the .p12 |
+| `MACOS_SIGNING_IDENTITY` | e.g. `Developer ID Application: GH S.R.L. (TEAMID)` |
+| `APPLE_ID` | Apple ID email used for notarization |
+| `APPLE_TEAM_ID` | 10-character team ID |
+| `APPLE_APP_SPECIFIC_PASSWORD` | app-specific password from appleid.apple.com |
+
+Once these exist, the next `v*` tag produces a signed, notarized, stapled DMG
+that opens cleanly on any Mac.
+
+## Distribution channels (later)
+
+- **GitHub Releases** — the DMG is attached automatically.
+- **Homebrew cask** — a `gh-notch.rb` cask pointing at the release DMG (the
+  README already advertises `brew install --cask gh-notch`). Add once releases
+  are signed.
+
+## Status
+
+- [x] Release workflow (builds + packages DMG)
+- [x] Unsigned DMG path
+- [ ] Apple Developer Program enrollment (blocks signed releases)
+- [ ] Signing secrets configured
+- [ ] First signed + notarized release
+- [ ] Homebrew cask

--- a/gh-notch/App/gh_notchApp.swift
+++ b/gh-notch/App/gh_notchApp.swift
@@ -7,17 +7,17 @@ import SwiftUI
 /// management happens in `AppDelegate` via AppKit, because the notch panel needs
 /// `NSPanel` APIs that SwiftUI does not expose.
 ///
-/// We deliberately declare an empty `Settings` scene rather than a `WindowGroup`:
-/// a `WindowGroup` would create a standard app window at launch, which we do not
-/// want. `Settings` provides a valid scene with no visible window until the user
-/// opens preferences (wired up in a later slice).
+/// We declare a `Settings` scene rather than a `WindowGroup`: a `WindowGroup`
+/// would create a standard app window at launch, which we do not want. `Settings`
+/// provides the ⌘, preferences window (the AI endpoint config) with no visible
+/// window until the user opens it.
 @main
 struct GhNotchApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     var body: some Scene {
         Settings {
-            EmptyView()
+            SettingsView()
         }
     }
 }

--- a/gh-notch/Features/CommandBar/AIDispatcher.swift
+++ b/gh-notch/Features/CommandBar/AIDispatcher.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Sends a free-form prompt to a configured AI backend and returns the reply.
+protocol AIDispatching {
+    func complete(prompt: String) async throws -> String
+}
+
+/// Errors surfaced to the user when remote dispatch fails.
+enum AIDispatchError: LocalizedError, Equatable {
+    case notConfigured
+    case invalidURL
+    case http(Int)
+    case emptyResponse
+    case decoding
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured: return "No AI endpoint configured. Open Settings to add one."
+        case .invalidURL: return "The endpoint URL is invalid."
+        case .http(let code): return "The server returned HTTP \(code)."
+        case .emptyResponse: return "The model returned an empty response."
+        case .decoding: return "Could not read the model's response."
+        }
+    }
+}
+
+/// Dispatcher for any OpenAI-compatible `/chat/completions` endpoint.
+///
+/// Works with OpenAI, Ollama's OpenAI-compatible API, and most proxies. The
+/// `URLSession` is injectable so the request/response handling is unit-tested
+/// with a stub `URLProtocol` (no network).
+struct OpenAICompatibleDispatcher: AIDispatching {
+    let endpoint: AIEndpoint
+    let apiKey: String
+    let session: URLSession
+
+    init(endpoint: AIEndpoint, apiKey: String, session: URLSession = .shared) {
+        self.endpoint = endpoint
+        self.apiKey = apiKey
+        self.session = session
+    }
+
+    func complete(prompt: String) async throws -> String {
+        guard endpoint.isConfigured else { throw AIDispatchError.notConfigured }
+        guard let url = endpoint.chatCompletionsURL else { throw AIDispatchError.invalidURL }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        let body = RequestBody(model: endpoint.model, messages: [.init(role: "user", content: prompt)])
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let http = response as? HTTPURLResponse else { throw AIDispatchError.emptyResponse }
+        guard (200..<300).contains(http.statusCode) else { throw AIDispatchError.http(http.statusCode) }
+
+        guard let decoded = try? JSONDecoder().decode(ResponseBody.self, from: data) else {
+            throw AIDispatchError.decoding
+        }
+        let content = decoded.choices.first?.message.content?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let content, !content.isEmpty else { throw AIDispatchError.emptyResponse }
+        return content
+    }
+
+    // MARK: - Wire format (OpenAI chat-completions subset)
+
+    private struct RequestBody: Encodable {
+        let model: String
+        let messages: [Message]
+    }
+
+    private struct Message: Codable {
+        let role: String
+        let content: String
+    }
+
+    private struct ResponseBody: Decodable {
+        let choices: [Choice]
+        struct Choice: Decodable {
+            let message: ResponseMessage
+        }
+        struct ResponseMessage: Decodable {
+            let content: String?
+        }
+    }
+}

--- a/gh-notch/Features/CommandBar/AIEndpoint.swift
+++ b/gh-notch/Features/CommandBar/AIEndpoint.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// User-configured AI backend for the command bar's remote dispatch.
+///
+/// Targets any OpenAI-compatible `/chat/completions` endpoint — OpenAI itself,
+/// a local Ollama server (`http://localhost:11434/v1`), or any compatible proxy.
+/// The API key is stored separately (Keychain), never in this value.
+struct AIEndpoint: Codable, Equatable {
+    /// Base URL including the API version segment, e.g.
+    /// `https://api.openai.com/v1` or `http://localhost:11434/v1`.
+    var baseURL: String
+    /// Model identifier, e.g. `gpt-4o-mini` or `llama3`.
+    var model: String
+
+    static let empty = AIEndpoint(baseURL: "", model: "")
+
+    /// Common presets surfaced in Settings.
+    static let openAI = AIEndpoint(baseURL: "https://api.openai.com/v1", model: "gpt-4o-mini")
+    static let ollama = AIEndpoint(baseURL: "http://localhost:11434/v1", model: "llama3")
+
+    /// The chat-completions URL, or `nil` if `baseURL` is not a valid URL.
+    var chatCompletionsURL: URL? {
+        let trimmed = baseURL.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+        let normalized = trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed
+        return URL(string: normalized + "/chat/completions")
+    }
+
+    /// Whether this endpoint is complete enough to dispatch to.
+    var isConfigured: Bool {
+        !model.trimmingCharacters(in: .whitespaces).isEmpty && chatCompletionsURL != nil
+    }
+}

--- a/gh-notch/Features/CommandBar/CommandBarView.swift
+++ b/gh-notch/Features/CommandBar/CommandBarView.swift
@@ -2,8 +2,10 @@ import SwiftUI
 
 /// The AI command bar: a Spotlight-style text field rendered in the notch.
 ///
-/// MVP: parses locally (math, counts, transforms, date). The result line shows
-/// underneath; a small badge marks whether it was resolved on-device.
+/// Parses locally first (math, counts, transforms, date); unrecognized queries
+/// dispatch to the configured AI endpoint. The result line shows underneath with
+/// a badge marking on-device vs. remote, and a spinner while a request is in
+/// flight.
 struct CommandBarView: View {
     @Bindable var viewModel: CommandBarViewModel
     @FocusState private var isFocused: Bool
@@ -20,7 +22,12 @@ struct CommandBarView: View {
                     .font(.system(size: 13))
                     .foregroundStyle(.primary)
                     .focused($isFocused)
-                    .onSubmit { viewModel.submit() }
+                    .onSubmit { Task { await viewModel.submit() } }
+
+                if viewModel.isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 7)
@@ -34,7 +41,7 @@ struct CommandBarView: View {
                     Image(systemName: result.handledLocally ? "lock.fill" : "cloud")
                         .font(.system(size: 9))
                         .foregroundStyle(result.handledLocally ? .green : .orange)
-                        .help(result.handledLocally ? "Resolved on-device" : "Would dispatch to your AI endpoint")
+                        .help(result.handledLocally ? "Resolved on-device" : "From your AI endpoint")
                     Text(result.output)
                         .font(.system(size: 12))
                         .foregroundStyle(.primary)
@@ -45,6 +52,7 @@ struct CommandBarView: View {
             }
         }
         .animation(.easeOut(duration: 0.15), value: viewModel.result)
+        .animation(.easeOut(duration: 0.15), value: viewModel.isLoading)
         .onAppear { isFocused = true }
     }
 }

--- a/gh-notch/Features/CommandBar/CommandBarViewModel.swift
+++ b/gh-notch/Features/CommandBar/CommandBarViewModel.swift
@@ -1,27 +1,78 @@
+import Foundation
 import Observation
 
 /// State for the command-bar input + last result.
+///
+/// Flow: parse locally first (privacy-first). If a local handler resolves the
+/// entry, show it immediately. Otherwise, if an AI endpoint is configured,
+/// dispatch the query remotely; if not, show the "configure an endpoint" hint.
 @Observable
+@MainActor
 final class CommandBarViewModel {
 
     var input: String = ""
     private(set) var result: CommandResult?
+    private(set) var isLoading = false
 
-    private let parser: CommandParser
+    @ObservationIgnored private let parser: CommandParser
+    @ObservationIgnored private let settings: SettingsStore
+    /// Test seam: when set, used instead of building a dispatcher from settings.
+    @ObservationIgnored private let dispatcherOverride: AIDispatching?
 
-    init(parser: CommandParser = CommandParser()) {
+    init(
+        parser: CommandParser = CommandParser(),
+        settings: SettingsStore = .shared,
+        dispatcher: AIDispatching? = nil
+    ) {
         self.parser = parser
+        self.settings = settings
+        self.dispatcherOverride = dispatcher
     }
 
-    /// Parse the current input and store the result. No-op on empty input.
-    func submit() {
-        guard let result = parser.parse(input) else { return }
-        self.result = result
+    /// Parse and resolve the current input. Local commands resolve synchronously;
+    /// unrecognized ones dispatch to the configured AI endpoint when available.
+    func submit() async {
+        guard let local = parser.parse(input) else { return }
+        if local.handledLocally {
+            result = local
+            return
+        }
+        guard settings.canDispatchRemotely else {
+            // Keep the parser's "configure an endpoint" hint.
+            result = local
+            return
+        }
+        await dispatchRemote(prompt: input)
     }
 
     /// Clear input and result (e.g. on collapse or Esc).
     func reset() {
         input = ""
         result = nil
+        isLoading = false
+    }
+
+    /// Whether the panel should stay open (busy or showing content) rather than
+    /// collapse when the pointer leaves.
+    var shouldStayOpen: Bool {
+        isLoading || !input.isEmpty || result != nil
+    }
+
+    // MARK: - Remote
+
+    private func dispatchRemote(prompt: String) async {
+        isLoading = true
+        result = nil
+        defer { isLoading = false }
+
+        let dispatcher = dispatcherOverride
+            ?? OpenAICompatibleDispatcher(endpoint: settings.endpoint, apiKey: settings.apiKey)
+        do {
+            let answer = try await dispatcher.complete(prompt: prompt)
+            result = CommandResult(output: answer, handledLocally: false)
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            result = CommandResult(output: message, handledLocally: false)
+        }
     }
 }

--- a/gh-notch/Features/CommandBar/SecretStore.swift
+++ b/gh-notch/Features/CommandBar/SecretStore.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Security
+
+/// Stores small secrets (the AI API key). Abstracted so the live app uses the
+/// Keychain while tests use an in-memory implementation (the CI runner has no
+/// usable login keychain).
+protocol SecretStoring {
+    func string(for key: String) -> String?
+    func set(_ value: String?, for key: String)
+}
+
+extension SecretStoring {
+    /// Convenience for the single secret this app stores today.
+    var apiKey: String {
+        get { string(for: SecretKey.apiKey) ?? "" }
+        nonmutating set { set(newValue.isEmpty ? nil : newValue, for: SecretKey.apiKey) }
+    }
+}
+
+enum SecretKey {
+    static let apiKey = "ai.apiKey"
+}
+
+/// Keychain-backed secret store (generic password items, scoped to the app's
+/// service identifier).
+struct KeychainSecretStore: SecretStoring {
+    private let service = "company.gh.notch"
+
+    func string(for key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    func set(_ value: String?, for key: String) {
+        let base: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+        SecItemDelete(base as CFDictionary)
+
+        guard let value, let data = value.data(using: .utf8) else { return }
+        var insert = base
+        insert[kSecValueData as String] = data
+        SecItemAdd(insert as CFDictionary, nil)
+    }
+}
+
+/// In-memory secret store for tests and previews.
+final class InMemorySecretStore: SecretStoring {
+    private var storage: [String: String] = [:]
+
+    func string(for key: String) -> String? { storage[key] }
+
+    func set(_ value: String?, for key: String) {
+        if let value { storage[key] = value } else { storage.removeValue(forKey: key) }
+    }
+}

--- a/gh-notch/Features/CommandBar/SettingsStore.swift
+++ b/gh-notch/Features/CommandBar/SettingsStore.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Observation
+
+/// Observable, persisted settings for the AI command bar.
+///
+/// Endpoint config (non-secret) persists to `UserDefaults`; the API key persists
+/// to the injected `SecretStoring` (Keychain in the app, in-memory in tests).
+/// Call `save()` after editing to write both.
+@Observable
+final class SettingsStore {
+
+    /// Shared instance used by the panel and the Settings window so both see the
+    /// same configuration.
+    static let shared = SettingsStore()
+
+    var endpoint: AIEndpoint
+    var apiKey: String
+
+    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private let secrets: SecretStoring
+
+    private static let endpointKey = "ai.endpoint"
+
+    init(defaults: UserDefaults = .standard, secrets: SecretStoring = KeychainSecretStore()) {
+        self.defaults = defaults
+        self.secrets = secrets
+
+        if let data = defaults.data(forKey: SettingsStore.endpointKey),
+           let decoded = try? JSONDecoder().decode(AIEndpoint.self, from: data) {
+            self.endpoint = decoded
+        } else {
+            self.endpoint = .empty
+        }
+        self.apiKey = secrets.apiKey
+    }
+
+    /// Persist the current endpoint config and API key.
+    func save() {
+        if let data = try? JSONEncoder().encode(endpoint) {
+            defaults.set(data, forKey: SettingsStore.endpointKey)
+        }
+        secrets.apiKey = apiKey
+    }
+
+    /// Whether the command bar can dispatch remote queries.
+    var canDispatchRemotely: Bool {
+        endpoint.isConfigured
+    }
+}

--- a/gh-notch/Notch/NotchView.swift
+++ b/gh-notch/Notch/NotchView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// SwiftUI root rendered inside the notch panel.
 ///
 /// Collapsed: a black pill that hugs the notch. Expanded (on hover/click): the
-/// MVP widgets — the local AI command bar and the battery HUD.
+/// AI command bar and the battery HUD.
 struct NotchView: View {
     @Bindable var viewModel: NotchViewModel
     @State private var isHovering = false
@@ -22,11 +22,12 @@ struct NotchView: View {
         .background(panelShape)
         .onHover { hovering in
             isHovering = hovering
-            // Hover-to-peek: expand on enter, collapse on leave. A click also
-            // toggles, for trackpad users who prefer an explicit tap.
+            // Hover-to-peek: expand on enter. On leave, only collapse if the
+            // command bar isn't mid-interaction (typing, a result on screen, or a
+            // request in flight) — otherwise the panel would vanish under the user.
             if hovering {
                 viewModel.expand()
-            } else {
+            } else if !commandBar.shouldStayOpen {
                 viewModel.collapse()
             }
         }

--- a/gh-notch/Settings/SettingsView.swift
+++ b/gh-notch/Settings/SettingsView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// The app's Settings window (⌘,). Configures the AI command bar's backend.
+///
+/// Endpoint config is saved to `UserDefaults`; the API key goes to the Keychain.
+/// Privacy note: nothing is sent anywhere until you configure an endpoint and
+/// submit a query the local handlers don't resolve.
+struct SettingsView: View {
+    @Bindable private var settings = SettingsStore.shared
+    @State private var didSave = false
+
+    var body: some View {
+        Form {
+            Section("AI Endpoint") {
+                TextField("Base URL", text: $settings.endpoint.baseURL)
+                    .textContentType(.URL)
+                TextField("Model", text: $settings.endpoint.model)
+                SecureField("API Key (stored in Keychain)", text: $settings.apiKey)
+
+                HStack {
+                    Button("OpenAI preset") { applyPreset(.openAI) }
+                    Button("Ollama (local) preset") { applyPreset(.ollama) }
+                }
+                .buttonStyle(.link)
+            }
+
+            Section {
+                Text("Local commands (math, counts, date) always run on-device. Free-form queries are sent to the endpoint above only when configured.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                HStack {
+                    Button("Save") {
+                        settings.save()
+                        didSave = true
+                    }
+                    .keyboardShortcut(.defaultAction)
+
+                    if didSave {
+                        Label("Saved", systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                            .font(.footnote)
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 440, height: 320)
+        .onChange(of: settings.endpoint) { didSave = false }
+        .onChange(of: settings.apiKey) { didSave = false }
+    }
+
+    private func applyPreset(_ preset: AIEndpoint) {
+        settings.endpoint = preset
+    }
+}

--- a/gh-notchTests/AIDispatcherTests.swift
+++ b/gh-notchTests/AIDispatcherTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import gh_notch
+
+final class AIDispatcherTests: XCTestCase {
+
+    private func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    private let endpoint = AIEndpoint(baseURL: "https://example.com/v1", model: "test-model")
+
+    override func tearDown() {
+        MockURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    /// Build an HTTP response for a given status, throwing if construction fails.
+    private static func response(_ request: URLRequest, status: Int) throws -> HTTPURLResponse {
+        let url = request.url ?? URL(fileURLWithPath: "/")
+        guard let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil) else {
+            throw URLError(.badServerResponse)
+        }
+        return response
+    }
+
+    func testSuccessfulCompletionReturnsContent() async throws {
+        MockURLProtocol.handler = { request in
+            let json = #"{"choices":[{"message":{"role":"assistant","content":"Paris"}}]}"#
+            return (try Self.response(request, status: 200), Data(json.utf8))
+        }
+        let dispatcher = OpenAICompatibleDispatcher(endpoint: endpoint, apiKey: "sk-test", session: makeSession())
+        let reply = try await dispatcher.complete(prompt: "capital of France?")
+        XCTAssertEqual(reply, "Paris")
+    }
+
+    func testHTTPErrorThrows() async {
+        MockURLProtocol.handler = { request in
+            (try Self.response(request, status: 500), Data())
+        }
+        let dispatcher = OpenAICompatibleDispatcher(endpoint: endpoint, apiKey: "", session: makeSession())
+        do {
+            _ = try await dispatcher.complete(prompt: "hi")
+            XCTFail("expected an error")
+        } catch {
+            XCTAssertEqual(error as? AIDispatchError, .http(500))
+        }
+    }
+
+    func testUnconfiguredEndpointThrows() async {
+        let dispatcher = OpenAICompatibleDispatcher(endpoint: .empty, apiKey: "", session: makeSession())
+        do {
+            _ = try await dispatcher.complete(prompt: "hi")
+            XCTFail("expected an error")
+        } catch {
+            XCTAssertEqual(error as? AIDispatchError, .notConfigured)
+        }
+    }
+
+    func testEmptyChoicesThrows() async {
+        MockURLProtocol.handler = { request in
+            (try Self.response(request, status: 200), Data(#"{"choices":[]}"#.utf8))
+        }
+        let dispatcher = OpenAICompatibleDispatcher(endpoint: endpoint, apiKey: "", session: makeSession())
+        do {
+            _ = try await dispatcher.complete(prompt: "hi")
+            XCTFail("expected an error")
+        } catch {
+            XCTAssertEqual(error as? AIDispatchError, .emptyResponse)
+        }
+    }
+}
+
+/// Intercepts URLSession requests so the dispatcher can be tested without network.
+final class MockURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/gh-notchTests/AISettingsTests.swift
+++ b/gh-notchTests/AISettingsTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import gh_notch
+
+final class AISettingsTests: XCTestCase {
+
+    // MARK: - AIEndpoint
+
+    func testChatCompletionsURLAppendsPath() {
+        let endpoint = AIEndpoint(baseURL: "https://api.openai.com/v1", model: "gpt-4o-mini")
+        XCTAssertEqual(endpoint.chatCompletionsURL?.absoluteString, "https://api.openai.com/v1/chat/completions")
+    }
+
+    func testChatCompletionsURLToleratesTrailingSlash() {
+        let endpoint = AIEndpoint(baseURL: "http://localhost:11434/v1/", model: "llama3")
+        XCTAssertEqual(endpoint.chatCompletionsURL?.absoluteString, "http://localhost:11434/v1/chat/completions")
+    }
+
+    func testIsConfigured() {
+        XCTAssertFalse(AIEndpoint.empty.isConfigured)
+        XCTAssertFalse(AIEndpoint(baseURL: "https://x.com/v1", model: "").isConfigured)
+        XCTAssertFalse(AIEndpoint(baseURL: "", model: "m").isConfigured)
+        XCTAssertTrue(AIEndpoint(baseURL: "https://x.com/v1", model: "m").isConfigured)
+    }
+
+    // MARK: - SettingsStore persistence
+
+    func testSaveAndReloadRoundTrips() {
+        let suite = UUID().uuidString
+        let defaults = UserDefaults(suiteName: suite) ?? .standard
+        let secrets = InMemorySecretStore()
+
+        let store = SettingsStore(defaults: defaults, secrets: secrets)
+        store.endpoint = AIEndpoint(baseURL: "https://api.openai.com/v1", model: "gpt-4o-mini")
+        store.apiKey = "sk-test-123"
+        store.save()
+
+        let reloaded = SettingsStore(defaults: defaults, secrets: secrets)
+        XCTAssertEqual(reloaded.endpoint.model, "gpt-4o-mini")
+        XCTAssertEqual(reloaded.endpoint.baseURL, "https://api.openai.com/v1")
+        XCTAssertEqual(reloaded.apiKey, "sk-test-123")
+        XCTAssertTrue(reloaded.canDispatchRemotely)
+
+        defaults.removePersistentDomain(forName: suite)
+    }
+
+    func testDefaultsToEmptyEndpoint() {
+        let defaults = UserDefaults(suiteName: UUID().uuidString) ?? .standard
+        let store = SettingsStore(defaults: defaults, secrets: InMemorySecretStore())
+        XCTAssertEqual(store.endpoint, .empty)
+        XCTAssertFalse(store.canDispatchRemotely)
+    }
+}

--- a/gh-notchTests/CommandBarViewModelTests.swift
+++ b/gh-notchTests/CommandBarViewModelTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import gh_notch
+
+@MainActor
+final class CommandBarViewModelTests: XCTestCase {
+
+    private func makeSettings(configured: Bool) -> SettingsStore {
+        let defaults = UserDefaults(suiteName: UUID().uuidString) ?? .standard
+        let store = SettingsStore(defaults: defaults, secrets: InMemorySecretStore())
+        if configured {
+            store.endpoint = .openAI
+        }
+        return store
+    }
+
+    func testLocalCommandResolvesWithoutDispatch() async {
+        let viewModel = CommandBarViewModel(
+            settings: makeSettings(configured: true),
+            dispatcher: FailingDispatcher()
+        )
+        viewModel.input = "2 + 2"
+        await viewModel.submit()
+        XCTAssertEqual(viewModel.result?.output, "4")
+        XCTAssertEqual(viewModel.result?.handledLocally, true)
+    }
+
+    func testRemoteDispatchWhenConfigured() async {
+        let viewModel = CommandBarViewModel(
+            settings: makeSettings(configured: true),
+            dispatcher: StubDispatcher(reply: "Paris")
+        )
+        viewModel.input = "capital of France"
+        await viewModel.submit()
+        XCTAssertEqual(viewModel.result?.output, "Paris")
+        XCTAssertEqual(viewModel.result?.handledLocally, false)
+        XCTAssertFalse(viewModel.isLoading)
+    }
+
+    func testUnconfiguredShowsLocalHint() async {
+        let viewModel = CommandBarViewModel(
+            settings: makeSettings(configured: false),
+            dispatcher: StubDispatcher(reply: "should not be used")
+        )
+        viewModel.input = "capital of France"
+        await viewModel.submit()
+        XCTAssertEqual(viewModel.result?.handledLocally, false)
+        XCTAssertTrue(viewModel.result?.output.contains("Settings") ?? false)
+    }
+
+    func testShouldStayOpenReflectsInteraction() {
+        let viewModel = CommandBarViewModel(settings: makeSettings(configured: false))
+        XCTAssertFalse(viewModel.shouldStayOpen)
+        viewModel.input = "hi"
+        XCTAssertTrue(viewModel.shouldStayOpen)
+        viewModel.reset()
+        XCTAssertFalse(viewModel.shouldStayOpen)
+    }
+}
+
+private struct StubDispatcher: AIDispatching {
+    let reply: String
+    func complete(prompt: String) async throws -> String { reply }
+}
+
+private struct FailingDispatcher: AIDispatching {
+    func complete(prompt: String) async throws -> String {
+        throw AIDispatchError.emptyResponse
+    }
+}


### PR DESCRIPTION
Everything fixable in code toward production. Stacks on the MVP PR (#3) — review/merge that first.

## The differentiator: remote AI dispatch
The command bar now actually does what the README promises. Unrecognized queries (anything the local handlers don't resolve) dispatch to a user-configured AI backend.
- **`AIDispatching` + `OpenAICompatibleDispatcher`** — POSTs to any OpenAI-compatible `/chat/completions` (OpenAI, **Ollama** local, proxies). Injectable `URLSession`; typed errors.
- **Privacy preserved** — local-first is unchanged; nothing leaves the device unless you configure an endpoint *and* the query isn't handled locally. The 🔒/☁️ badge shows which path ran.
- Async `submit()` with a loading spinner.

## Settings (⌘,)
- **`SettingsView`** — base URL, model, API key, OpenAI/Ollama presets, Save.
- **`SettingsStore`** — endpoint config → `UserDefaults`; **API key → Keychain** (`KeychainSecretStore`). `SecretStoring` protocol keeps the Keychain out of CI (tests use `InMemorySecretStore`).
- App now exposes a real `Settings` scene (was `EmptyView`).

## UX fix
The panel no longer collapses out from under you while typing — hover-leave only collapses when the command bar is idle (`shouldStayOpen`).

## Production infra
- **`.github/workflows/release.yml`** — on a `v*` tag: build → (sign + notarize if secrets present) → DMG → GitHub Release. **Gated**: produces an unsigned DMG today, a signed+notarized one once the Apple cert secrets exist.
- **`RELEASING.md`** — exact secrets + steps, and the standing blocker spelled out.

## Tests (+15 assertions)
`AIDispatcherTests` (stub URLProtocol: success/HTTP-error/empty/unconfigured), `AISettingsTests` (URL building, config, persistence round-trip), `CommandBarViewModelTests` (local resolve, remote dispatch, unconfigured hint, stay-open). CI runs them on this PR.

## Still NOT production — unchanged blockers
1. **Never been run.** All of this is CI-verified (compiles + unit tests), but the UI — Settings window, command-bar focus, spinner, the collapse fix — has not been seen by a human. Needs Xcode on a notched Mac.
2. **Can't be distributed** until GH enrolls in the Apple Developer Program ($99/yr) and the signing secrets are added. The pipeline is ready and waiting for exactly that.

Not in scope: media controls, calendar, file shelf, system HUD; streaming AI responses; conversation history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)