### PR TITLE
docs: real roadmap + install/download + Homebrew cask

### DIFF
--- a/Casks/gh-notch.rb
+++ b/Casks/gh-notch.rb
@@ -1,0 +1,27 @@
+# Homebrew cask for gh-notch.
+#
+# Until releases are code-signed + notarized, sha256 is left unchecked and the
+# app is unsigned (right-click → Open on first launch). Once a signed DMG ships,
+# replace `sha256 :no_check` with the real checksum.
+#
+# Install (after the first release is published, via a tap repo named
+# `homebrew-tap`):
+#   brew tap aymandakir-gh/tap
+#   brew install --cask gh-notch
+cask "gh-notch" do
+  version "0.1.0"
+  sha256 :no_check
+
+  url "https://github.com/aymandakir-gh/gh-notch/releases/download/v#{version}/gh-notch-v#{version}.dmg"
+  name "gh-notch"
+  desc "Open-source macOS notch utility with a local-first AI command bar"
+  homepage "https://github.com/aymandakir-gh/gh-notch"
+
+  depends_on macos: ">= :sonoma"
+
+  app "gh-notch.app"
+
+  zap trash: [
+    "~/Library/Preferences/company.gh.notch.plist",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -2,96 +2,133 @@
 
 **Your Mac's notch, reimagined. AI commands + media + calendar + file shelf — all in one place. Free. Open source. MIT.**
 
-![macOS 14+](https://img.shields.io/badge/macOS-14%2B-blue) ![Swift](https://img.shields.io/badge/Swift-5.9%2B-orange) ![License: MIT](https://img.shields.io/badge/license-MIT-green) ![Status: WIP](https://img.shields.io/badge/status-WIP-yellow)
+![macOS 14+](https://img.shields.io/badge/macOS-14%2B-blue) ![Swift](https://img.shields.io/badge/Swift-5.9%2B-orange) ![License: MIT](https://img.shields.io/badge/license-MIT-green) ![Status: alpha](https://img.shields.io/badge/status-alpha-orange) ![CI](https://github.com/aymandakir-gh/gh-notch/actions/workflows/ci.yml/badge.svg)
+
+> **Status: early alpha (v0.1).** The notch foundation, AI command bar, and battery HUD are built and tested in CI. Media, calendar, file shelf, and system HUD are on the roadmap below. Follow [Releases](https://github.com/aymandakir-gh/gh-notch/releases) to track progress.
 
 ---
 
 ## Features
 
-### AI Command Bar ✨ — the differentiator
-Type any command directly in the notch. gh-notch parses it locally first, then dispatches to an AI agent of your choice (Ollama, Claude, OpenAI — your endpoint, your data). Spotlight-style speed, zero friction.
+The table further down is the **v1.0 vision**. For what works *today*, see the [Roadmap](#roadmap) — shipped items are checked.
 
-### Media Controls + Visualizer
-Album art, playback controls, and a live audio visualizer — all rendered in the notch without covering any screen real estate.
+### AI Command Bar ✨ — the differentiator — *shipped (local + remote)*
+Type any command directly in the notch. gh-notch parses it **locally first** (math, word/character count, text transforms, date — all on-device), then dispatches anything else to an AI agent of your choice (Ollama, OpenAI, or any OpenAI-compatible endpoint — **your endpoint, your key, your data**). A 🔒/☁️ badge shows whether a result was resolved on-device or sent to your model. Nothing leaves your Mac unless you configure an endpoint.
 
-### Calendar & Reminders
+### Battery HUD — *shipped*
+Clean battery indicator with charge level, charging state, and time-remaining estimate.
+
+### Media Controls + Visualizer — *planned (v0.2)*
+Album art, playback controls, and a live audio visualizer — rendered in the notch without covering any screen real estate.
+
+### Calendar & Reminders — *planned (v0.2)*
 Your next event, always visible. Click to expand a mini-calendar with upcoming reminders.
 
-### File Shelf with AirDrop
-Drag files into the notch to hold them temporarily. AirDrop from there. Never lose a file mid-workflow again.
+### File Shelf with AirDrop — *planned (v0.3)*
+Drag files into the notch to hold them temporarily. AirDrop from there.
 
-### Battery HUD
-Clean battery indicator with time-remaining estimate. Replaces the menu bar icon clutter.
-
-### Custom HUD
-Replaces the default macOS brightness/volume overlay with a sleek notch-native HUD. No more floating boxes in the middle of your screen.
+### Custom HUD — *planned (v0.3)*
+Replaces the default macOS brightness/volume overlay with a sleek notch-native HUD.
 
 ---
 
 ## gh-notch vs alternatives
 
+*Reflects the v1.0 vision. See the [Roadmap](#roadmap) for current status.*
+
 | Feature | gh-notch | Boring Notch | NotchNook |
 |---|---|---|---|
-| Price | Free | Free | Paid |
-| AI Command Bar | Yes | No | No |
-| Open Source | MIT | GPL | Closed |
-| Media Controls | Yes | Yes | Yes |
-| Calendar | Yes | No | Yes |
-| File Shelf | Yes | No | Yes |
-| Battery HUD | Yes | Yes | Yes |
-| Custom HUD | Yes | No | No |
-| Local AI (Ollama) | Yes | N/A | N/A |
+| Price | **Free** | Free | Paid |
+| AI Command Bar | **Yes** | No | No |
+| Open Source | **MIT** | GPL | Closed |
+| Media Controls | Planned | Yes | Yes |
+| Calendar | Planned | No | Yes |
+| File Shelf | Planned | No | Yes |
+| Battery HUD | **Yes** | Yes | Yes |
+| Custom HUD | Planned | No | No |
+| Local AI (Ollama) | **Yes** | N/A | N/A |
 
 ---
 
 ## Requirements
 
 - macOS 14 Sonoma or later
-- Apple Silicon or Intel Mac with a notch (MacBook Pro 2021+, MacBook Air 2022+)
-- Xcode 16+ (to build from source)
+- Apple Silicon or Intel Mac (notch optional — degrades to a top-center bar without one)
+- Xcode 16+ and [XcodeGen](https://github.com/yonaskolb/XcodeGen) (to build from source)
 
 ---
 
 ## Installation
 
-### Homebrew (coming soon)
+### Download the app
+
+Grab the latest `.dmg` from the [**Releases**](https://github.com/aymandakir-gh/gh-notch/releases) page. Each tagged version is built automatically by CI.
+
+> **Early builds are unsigned.** Until the project is code-signed and notarized (tracked in [RELEASING.md](RELEASING.md)), macOS Gatekeeper will warn on first launch. To open an unsigned build: **right-click the app → Open → Open**. You only do this once.
+
+### Homebrew
+
+A Homebrew cask ships in [`Casks/gh-notch.rb`](Casks/gh-notch.rb). Once the first release is published it can be installed via a tap:
+
 ```bash
+brew tap aymandakir-gh/tap
 brew install --cask gh-notch
 ```
 
-### Download .dmg (coming soon)
-Check the [Releases](https://github.com/aymandakir-gh/gh-notch/releases) page.
+(Until a signed build is available in the official homebrew-cask, the tap is the supported path.)
 
 ### Build from source
+
 ```bash
 git clone https://github.com/aymandakir-gh/gh-notch.git
 cd gh-notch
-open gh-notch.xcodeproj   # Xcode 16+
+brew install xcodegen      # the .xcodeproj is generated, not committed
+xcodegen generate
+open gh-notch.xcodeproj     # Xcode 16+
 ```
-Set your signing team in project settings, then Cmd+R.
 
-See [DEVELOPMENT.md](DEVELOPMENT.md) for the full setup guide.
+Set your signing team in **Signing & Capabilities**, then **⌘R**. See [DEVELOPMENT.md](DEVELOPMENT.md) for the full guide.
 
 ---
 
-## Roadmap (v0.1)
+## Roadmap
 
-- [ ] AI Command Bar (Spotlight-style, dispatches to AI)
-- [ ] Media Controls + album art visualizer
-- [ ] Calendar integration
-- [ ] File Shelf with drag-and-drop
-- [ ] Battery HUD
-- [ ] System HUD replacement (brightness / volume)
-- [ ] Extension system
-- [ ] Voice commands
+Tracked release-by-release. ✅ = shipped, ⬜ = planned.
+
+### v0.1 — Foundation & AI command bar *(current)*
+- ✅ Notch panel foundation — `NSPanel` above the menu bar, runtime notch geometry, expand/collapse
+- ✅ AI Command Bar — local commands (math, counts, transforms, date)
+- ✅ AI Command Bar — remote dispatch (OpenAI / Ollama / any OpenAI-compatible endpoint)
+- ✅ Settings window — endpoint config, API key stored in Keychain
+- ✅ Battery HUD — level, charging state, time estimate
+- ✅ CI (build + test + lint) and a signed-release pipeline
+
+### v0.2 — Media & time
+- ⬜ Media controls + now-playing
+- ⬜ Album-art audio visualizer
+- ⬜ Calendar & reminders (next event + mini-calendar)
+
+### v0.3 — Files & system
+- ⬜ File Shelf with drag-and-drop + AirDrop
+- ⬜ System HUD replacement (brightness / volume)
+
+### v0.4+ — Power user
+- ⬜ Streaming AI responses + recent-query history
+- ⬜ Extension system (third-party notch widgets)
+- ⬜ Voice commands
+- ⬜ Menu-bar companion
+
+---
+
+## Free & open — forever
+
+gh-notch is and will remain **free and open source under the [MIT license](LICENSE)**. No paid tiers, no ads, **no telemetry**. Your AI queries go only to the endpoint *you* configure; everything the local handlers resolve never leaves your Mac. Contributions welcome.
 
 ---
 
 ## Contributing
 
-Pull requests are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening one.
-
-For architecture context, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+Pull requests are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) first. For architecture context, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md); to cut a release, see [RELEASING.md](RELEASING.md).
 
 ---
 


### PR DESCRIPTION
Makes the README honest and sets up downloads. Stacks on #4.

- **Roadmap rewritten** release-by-release: v0.1 (shipped — foundation, AI command bar local+remote, Settings, Battery HUD, CI+release pipeline) ✅, v0.2 (media, calendar), v0.3 (file shelf, system HUD), v0.4+ (streaming, extensions, voice). Replaces the flat all-unchecked v0.1 list.
- **Install section fixed** — build-from-source now uses `xcodegen generate` (was the wrong `open gh-notch.xcodeproj`); download points at Releases with the honest unsigned-build right-click-Open note; Homebrew via tap.
- **Homebrew cask** at `Casks/gh-notch.rb`, ready for the first tagged release.
- **"Free & open — forever"** section: MIT, no ads, no telemetry, bring-your-own-AI-endpoint.
- Feature table marked as the v1.0 vision so it doesn't overclaim unbuilt features.

The README links work the moment a release exists — which happens automatically when a `v*` tag is pushed (see RELEASING.md / the release workflow from #4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)