### PR TITLE
feat: notch redesign — minimal collapsed, compact useful panel + installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
-# Builds, (optionally) signs + notarizes, packages a DMG, and attaches it to a
-# GitHub Release when a v* tag is pushed.
+# Builds, (optionally) signs + notarizes, packages a styled DMG, and attaches it
+# to a GitHub Release when a v* tag is pushed.
 #
 # Signing + notarization run ONLY when the signing secrets are present. Until the
 # GH Apple Developer Program account exists, pushing a tag still produces an
@@ -44,7 +44,7 @@ jobs:
           xcode-version: "16"
 
       - name: Install tooling
-        run: brew install xcodegen create-dmg
+        run: brew install xcodegen create-dmg librsvg
 
       - name: Generate Xcode project
         run: xcodegen generate
@@ -99,14 +99,29 @@ jobs:
             --wait
           xcrun stapler staple "build/export/gh-notch.app"
 
+      - name: Render DMG background (Retina)
+        run: |
+          set -euo pipefail
+          mkdir -p build/dmg
+          rsvg-convert -w 660  -h 420 installer/background.svg -o build/dmg/background.png
+          rsvg-convert -w 1320 -h 840 installer/background.svg -o build/dmg/background@2x.png
+          tiffutil -cathidpicheck build/dmg/background.png build/dmg/background@2x.png \
+            -out build/dmg/background.tiff
+
       - name: Create DMG
         run: |
           set -euo pipefail
           create-dmg \
             --volname "gh-notch" \
-            --window-size 540 380 \
-            --icon-size 100 \
-            --app-drop-link 380 180 \
+            --background "build/dmg/background.tiff" \
+            --window-pos 200 120 \
+            --window-size 660 420 \
+            --icon-size 120 \
+            --text-size 13 \
+            --icon "gh-notch.app" 165 210 \
+            --hide-extension "gh-notch.app" \
+            --app-drop-link 495 210 \
+            --no-internet-enable \
             "build/gh-notch-${GITHUB_REF_NAME}.dmg" \
             "build/export/" || \
           hdiutil create -volname "gh-notch" -srcfolder "build/export/" -ov -format UDZO \

--- a/gh-notch/Features/Battery/BatteryView.swift
+++ b/gh-notch/Features/Battery/BatteryView.swift
@@ -1,14 +1,15 @@
 import SwiftUI
 
 /// Compact battery indicator: SF Symbol that reflects level + charging state,
-/// the percentage, and a time estimate when macOS provides one.
+/// the percentage, and a time estimate when macOS provides one. Content-sized so
+/// the parent controls layout.
 struct BatteryView: View {
     @Bindable var monitor: BatteryMonitor
 
     var body: some View {
         let snapshot = monitor.snapshot
 
-        HStack(spacing: 8) {
+        HStack(spacing: 6) {
             Image(systemName: symbolName(for: snapshot))
                 .font(.system(size: 15))
                 .foregroundStyle(tint(for: snapshot))
@@ -19,19 +20,11 @@ struct BatteryView: View {
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.primary)
                     .monospacedDigit()
-
-                if let time = snapshot.timeDescription {
-                    Text(time)
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                }
             } else {
                 Text("No battery")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }
-
-            Spacer(minLength: 0)
         }
     }
 
@@ -56,7 +49,6 @@ struct BatteryView: View {
 
 #Preview {
     BatteryView(monitor: BatteryMonitor())
-        .frame(width: 200)
         .padding()
         .background(Color.black)
 }

--- a/gh-notch/Features/Clock/ClockModel.swift
+++ b/gh-notch/Features/Clock/ClockModel.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Observation
+
+/// Observable clock: current time + localized date, ticking each second while the
+/// panel is open. Injectable clock for tests.
+@Observable
+final class ClockModel {
+
+    private(set) var now: Date
+
+    @ObservationIgnored private let clock: () -> Date
+    @ObservationIgnored private var timer: Timer?
+
+    init(clock: @escaping () -> Date = Date.init) {
+        self.clock = clock
+        self.now = clock()
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    /// Begin ticking. Called when the panel expands.
+    func start() {
+        guard timer == nil else { return }
+        tick()
+        let timer = Timer(timeInterval: 1, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    /// Stop ticking. Called when the panel collapses.
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func tick() {
+        now = clock()
+    }
+
+    var timeText: String { ClockModel.timeFormatter.string(from: now) }
+    var dateText: String { ClockModel.dateFormatter.string(from: now) }
+
+    static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("HHmm")
+        return formatter
+    }()
+
+    static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("EEEEdMMMM")
+        return formatter
+    }()
+}

--- a/gh-notch/Features/Clock/ClockView.swift
+++ b/gh-notch/Features/Clock/ClockView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Compact time + date display for the expanded panel.
+struct ClockView: View {
+    @Bindable var model: ClockModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(model.timeText)
+                .font(.system(size: 26, weight: .semibold))
+                .monospacedDigit()
+                .foregroundStyle(.primary)
+            Text(model.dateText)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+}
+
+#Preview {
+    ClockView(model: ClockModel())
+        .padding()
+        .background(Color.black)
+}

--- a/gh-notch/Notch/NotchPanel.swift
+++ b/gh-notch/Notch/NotchPanel.swift
@@ -9,6 +9,7 @@ import SwiftUI
 final class NotchPanel: NSPanel {
 
     private let viewModel: NotchViewModel
+    private var clickAwayMonitor: Any?
 
     init(viewModel: NotchViewModel) {
         self.viewModel = viewModel
@@ -38,14 +39,21 @@ final class NotchPanel: NSPanel {
             .ignoresCycle
         ]
 
-        // Re-frame the window whenever the view model expands/collapses.
+        // Re-frame the window and manage the click-away monitor on expand/collapse.
         viewModel.onLayoutChange = { [weak self] in
             self?.applyCurrentFrame()
+            self?.updateClickAwayMonitor()
+        }
+    }
+
+    deinit {
+        if let clickAwayMonitor {
+            NSEvent.removeMonitor(clickAwayMonitor)
         }
     }
 
     /// Borderless panels return `false` by default; allow key so SwiftUI focus
-    /// (e.g. the future AI command bar text field) can work when expanded.
+    /// (the command bar text field) works when expanded.
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
 
@@ -77,6 +85,23 @@ final class NotchPanel: NSPanel {
             }
         } else {
             setFrame(frame, display: true)
+        }
+    }
+
+    /// While expanded, watch for clicks outside the panel (i.e. in another app or
+    /// on the desktop) and collapse. Global monitors only fire for events the app
+    /// does not receive itself, so clicks inside the panel are unaffected.
+    private func updateClickAwayMonitor() {
+        if viewModel.isExpanded {
+            guard clickAwayMonitor == nil else { return }
+            clickAwayMonitor = NSEvent.addGlobalMonitorForEvents(
+                matching: [.leftMouseDown, .rightMouseDown]
+            ) { [weak self] _ in
+                self?.viewModel.collapse()
+            }
+        } else if let monitor = clickAwayMonitor {
+            NSEvent.removeMonitor(monitor)
+            clickAwayMonitor = nil
         }
     }
 }

--- a/gh-notch/Notch/NotchView.swift
+++ b/gh-notch/Notch/NotchView.swift
@@ -2,13 +2,16 @@ import SwiftUI
 
 /// SwiftUI root rendered inside the notch panel.
 ///
-/// Collapsed: a black pill that hugs the notch. Expanded (on hover/click): the
-/// AI command bar and the battery HUD.
+/// Collapsed: blends with the physical notch (minimal, click to open).
+/// Expanded: a compact panel with the AI command bar plus a clock/date + battery
+/// utility row. Opens on click; closes on Esc or a click outside (handled by the
+/// panel). No hover — hover on a screen-saver-level panel is unreliable and was
+/// leaving the panel stuck open.
 struct NotchView: View {
     @Bindable var viewModel: NotchViewModel
-    @State private var isHovering = false
     @State private var commandBar = CommandBarViewModel()
     @State private var battery = BatteryMonitor()
+    @State private var clock = ClockModel()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -20,58 +23,62 @@ struct NotchView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(panelShape)
-        .onHover { hovering in
-            isHovering = hovering
-            // Hover-to-peek: expand on enter. On leave, only collapse if the
-            // command bar isn't mid-interaction (typing, a result on screen, or a
-            // request in flight) — otherwise the panel would vanish under the user.
-            if hovering {
-                viewModel.expand()
-            } else if !commandBar.shouldStayOpen {
-                viewModel.collapse()
-            }
-        }
         .animation(.easeOut(duration: 0.22), value: viewModel.isExpanded)
     }
 
-    // MARK: - Collapsed
+    // MARK: - Collapsed (minimal: hugs the notch, click to open)
 
     private var collapsedBar: some View {
-        HStack {
-            Spacer(minLength: 0)
-        }
-        .frame(height: collapsedHeight)
-        .contentShape(Rectangle())
-        .onTapGesture { viewModel.toggle() }
+        Color.clear
+            .frame(height: collapsedHeight)
+            .contentShape(Rectangle())
+            .onTapGesture { viewModel.toggle() }
     }
 
     private var collapsedHeight: CGFloat {
         viewModel.geometry?.notchHeight ?? NotchGeometry.fallbackHeight
     }
 
-    // MARK: - Expanded
+    // MARK: - Expanded (command bar + clock/date + battery)
 
     private var expandedSurface: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 10) {
             CommandBarView(viewModel: commandBar)
-            Divider()
-                .overlay(Color.white.opacity(0.1))
-            BatteryView(monitor: battery)
+
+            Divider().overlay(Color.white.opacity(0.08))
+
+            HStack(alignment: .center, spacing: 12) {
+                ClockView(model: clock)
+                Spacer(minLength: 8)
+                BatteryView(monitor: battery)
+                SettingsLink {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Settings")
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(14)
-        .onAppear { battery.start() }
+        .onExitCommand { viewModel.collapse() }
+        .onAppear {
+            battery.start()
+            clock.start()
+        }
         .onDisappear {
             battery.stop()
+            clock.stop()
             commandBar.reset()
         }
     }
 
     // MARK: - Shape
 
-    /// The notch silhouette: square top corners (flush with the screen edge),
-    /// rounded bottom corners. Expanding only grows downward, so the top stays
-    /// glued to the physical notch.
+    /// Notch silhouette: square top corners (flush with the screen edge), rounded
+    /// bottom corners. Expanding only grows downward, so the top stays glued to
+    /// the physical notch.
     private var panelShape: some View {
         UnevenRoundedRectangle(
             topLeadingRadius: 0,
@@ -94,12 +101,12 @@ struct NotchView: View {
     }
 
     private var bottomRadius: CGFloat {
-        viewModel.isExpanded ? 16 : 10
+        viewModel.isExpanded ? 18 : 8
     }
 }
 
 #Preview {
     NotchView(viewModel: NotchViewModel())
-        .frame(width: 380, height: 200)
+        .frame(width: 360, height: 200)
         .background(Color.gray)
 }

--- a/gh-notch/Notch/NotchViewModel.swift
+++ b/gh-notch/Notch/NotchViewModel.swift
@@ -21,9 +21,9 @@ final class NotchViewModel {
     /// replaces the sampled width. Stubbed now; no UI yet.
     var notchWidthOverride: CGFloat?
 
-    /// Size of the expanded surface. Sized for the MVP widgets (command bar +
-    /// battery row); features will later drive this from their content.
-    let expandedSize = NSSize(width: 380, height: 168)
+    /// Size of the expanded surface. Tight to the command bar + clock/battery row
+    /// so there is no empty black void.
+    let expandedSize = NSSize(width: 360, height: 150)
 
     /// Invoked after any state change that alters `currentFrame` (expand/collapse).
     /// The panel sets this to reposition/resize its window. Not part of observable

--- a/gh-notchTests/ClockModelTests.swift
+++ b/gh-notchTests/ClockModelTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import gh_notch
+
+final class ClockModelTests: XCTestCase {
+
+    func testNowReflectsInjectedClock() {
+        let fixed = Date(timeIntervalSince1970: 0)
+        let model = ClockModel(clock: { fixed })
+        XCTAssertEqual(model.now, fixed)
+    }
+
+    func testTimeAndDateTextAreNonEmpty() {
+        let fixed = Date(timeIntervalSince1970: 1_700_000_000)
+        let model = ClockModel(clock: { fixed })
+        XCTAssertFalse(model.timeText.isEmpty)
+        XCTAssertFalse(model.dateText.isEmpty)
+    }
+}

--- a/installer/background.svg
+++ b/installer/background.svg
@@ -1,0 +1,50 @@
+<svg width="660" height="420" viewBox="0 0 660 420" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#14141b"/>
+      <stop offset="0.55" stop-color="#0d0d12"/>
+      <stop offset="1" stop-color="#070709"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.46" r="0.6">
+      <stop offset="0" stop-color="#2b6cff" stop-opacity="0.16"/>
+      <stop offset="1" stop-color="#2b6cff" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="arrow" gradientUnits="userSpaceOnUse" x1="250" y1="210" x2="412" y2="210">
+      <stop offset="0" stop-color="#4f8cff"/>
+      <stop offset="1" stop-color="#36d39a"/>
+    </linearGradient>
+    <filter id="soft" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="6"/>
+    </filter>
+  </defs>
+
+  <!-- Backdrop -->
+  <rect width="660" height="420" fill="url(#bg)"/>
+  <rect width="660" height="420" fill="url(#glow)"/>
+
+  <!-- Title + subtitle -->
+  <text x="330" y="84" text-anchor="middle"
+        font-family="-apple-system, SF Pro Display, Helvetica, Arial, sans-serif"
+        font-size="30" font-weight="700" fill="#ffffff" letter-spacing="0.2">gh-notch</text>
+  <text x="330" y="112" text-anchor="middle"
+        font-family="-apple-system, SF Pro Text, Helvetica, Arial, sans-serif"
+        font-size="13" font-weight="500" fill="#9aa0ab">Drag gh-notch into Applications to install</text>
+
+  <!-- Soft platforms under each icon slot (icons are drawn by Finder on top) -->
+  <ellipse cx="165" cy="298" rx="78" ry="14" fill="#000000" opacity="0.45" filter="url(#soft)"/>
+  <ellipse cx="495" cy="298" rx="78" ry="14" fill="#000000" opacity="0.45" filter="url(#soft)"/>
+
+  <!-- Move indicator: arrow from the app toward Applications -->
+  <text x="330" y="184" text-anchor="middle"
+        font-family="-apple-system, SF Pro Text, Helvetica, Arial, sans-serif"
+        font-size="11" font-weight="700" fill="#6b7280" letter-spacing="1.5">INSTALL</text>
+  <g stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <line x1="252" y1="210" x2="394" y2="210" stroke="url(#arrow)" stroke-width="7"/>
+    <path d="M 390 195 L 414 210 L 390 225" stroke="url(#arrow)" stroke-width="7"/>
+  </g>
+
+  <!-- Footer -->
+  <text x="330" y="402" text-anchor="middle"
+        font-family="-apple-system, SF Pro Text, Helvetica, Arial, sans-serif"
+        font-size="11" font-weight="500" fill="#565b66">macOS 14+   ·   Free &amp; open source   ·   MIT</text>
+</svg>


### PR DESCRIPTION
Fixes the v0.1.0 first-run feedback: the panel was stuck open as a big black box showing only the battery. Also folds in the sleek DMG installer (was PR #6). This is the **v0.1.1** payload.

## Notch UX redesign
- **Collapsed = minimal.** Blends with the physical notch, no big black box. Click to open.
- **Removed hover.** Hover on a `.screenSaver`-level panel is unreliable and was leaving it stuck open. Now: **click to open, click-away or Esc to close** (global mouse monitor + `onExitCommand`).
- **Compact, useful expanded panel**, tightened to content (150px, no empty void): AI command bar on top, then a utility row with **large clock + localized date**, **battery**, and a **Settings (⌘,) gear**.
- **More utility:** added clock/date (real, no permissions, CI-testable). Media + calendar land in v0.2.

## Installer (from #6)
- `installer/background.svg` — branded dark background with blue→green drag-to-install arrow.
- `release.yml` renders it to a Retina `.tiff` and lays out the DMG (660×420, app → Applications).

## Tests
- `ClockModelTests` (injected clock + formatting). Existing suite unchanged.

## Honest notes
- **Still unverified visually** — I can't run it; this is my best reasoning from your screenshots. The click-away monitor and Esc handling especially need a real run. Expect possibly one more tuning pass.
- The fast fix for this loop remains **local Xcode** (build+run in seconds vs. a 10-min release round-trip).

Supersedes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)